### PR TITLE
design: WrapperDiv에 margin-bottom 추가 및 MoreSmallIcon에 position 수정 (#60)

### DIFF
--- a/src/components/common/Post/Post.jsx
+++ b/src/components/common/Post/Post.jsx
@@ -48,16 +48,17 @@ export default Post;
 
 const WrapperDiv = styled.div`
   width: 35.8rem;
-  margin: 0 auto;
+  margin: 0 auto 20px;
 `;
 
 const UserInfoWrapperDiv = styled.div`
   display: flex;
+  position: relative;
   cursor: pointer;
 `;
 
 const UserInfoDiv = styled.div`
-  margin: 0.4rem 15rem 0 1.2rem;
+  margin: 0.4rem 0 0 1.2rem;
 `;
 
 const UserName = styled.strong`
@@ -75,6 +76,8 @@ const UserId = styled.p`
 `;
 
 const MoreSmallIcon = styled.img`
+  position: absolute;
+  right: 0;
   width: 1.8rem;
   height: 1.8rem;
   margin-top: 0.4rem;

--- a/src/components/common/Post/Post.jsx
+++ b/src/components/common/Post/Post.jsx
@@ -48,7 +48,7 @@ export default Post;
 
 const WrapperDiv = styled.div`
   width: 35.8rem;
-  margin: 0 auto 20px;
+  margin: 0 auto 2rem;
 `;
 
 const UserInfoWrapperDiv = styled.div`


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- Post 컴포넌트의 WrapperDiv에 margin-bottom 20px 추가를 위해서
- MoreSmallIcon의 position 수정을 위해서




## 관련 이슈 번호
close : #60 
