### PR TITLE
design: TopMainNav, TopTitleNav의 title을 props로 받도록 변경 (#59)

### DIFF
--- a/src/components/common/TopNavBar/TopMainNav.jsx
+++ b/src/components/common/TopNavBar/TopMainNav.jsx
@@ -4,10 +4,10 @@ import styled from 'styled-components';
 import { TopNavBar, SearchBtn } from './Styled';
 import { SEARCH_ICON } from '../../../styles/CommonIcons';
 
-const TopMainNav = () => {
+const TopMainNav = ({ title }) => {
   return (
     <TopNavBar>
-      <TopNavH2>가져도댕냥 피드</TopNavH2>
+      <TopNavH1>{title}</TopNavH1>
       <SearchBtn>
         <img src={SEARCH_ICON} alt='검색하기 버튼' />
       </SearchBtn>
@@ -17,6 +17,6 @@ const TopMainNav = () => {
 
 export default TopMainNav;
 
-const TopNavH2 = styled.h2`
+const TopNavH1 = styled.h1`
   font-size: var(--fs-xl);
 `;

--- a/src/components/common/TopNavBar/TopTitleNav.jsx
+++ b/src/components/common/TopNavBar/TopTitleNav.jsx
@@ -5,13 +5,13 @@ import { Link } from 'react-router-dom';
 import { TopNavBar, LeftArrow, MoreBtn } from './Styled';
 import { LEFT_ARROW_ICON, MORE_ICON } from '../../../styles/CommonIcons';
 
-const TopChatNav = () => {
+const TopTitleNav = ({ title }) => {
   return (
     <TopNavBar>
       <Link to='/'>
         <LeftArrow src={LEFT_ARROW_ICON} alt='뒤로가기 버튼' />
       </Link>
-      <TopNavH3>애월읍 위니브 감귤농장</TopNavH3>
+      <TopNavH2>{title}</TopNavH2>
       <MoreBtn>
         <img src={MORE_ICON} alt='더보기 버튼' />
       </MoreBtn>
@@ -19,9 +19,9 @@ const TopChatNav = () => {
   );
 };
 
-export default TopChatNav;
+export default TopTitleNav;
 
-const TopNavH3 = styled.h3`
+const TopNavH2 = styled.h2`
   font-size: var(--fs-md);
   flex-grow: 1;
   margin-left: 1em;


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 용이한 재사용을 위해 변경하였습니다.


## 기대 결과
- TopChatNav의 파일명이 TopTitleNav로 변경됩니다.
- TopMainNav에 title=''을 통해 제목을 전달할 수 있습니다.
`<TopMainNav title='안녕' />`
- TopTitleNav에 title=''을 통해 제목을 전달할 수 있습니다.
`<TopTitleNav title='안녕' />`


## 관련 이슈 번호
close : #59 
