### PR TITLE
design: 피드 페이지 퍼블리싱 (#38)

### DIFF
--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+import TopMainNav from '../.././components/common/TopNavBar/TopMainNav';
+import ContentsLayout from '../../components/layout/ContentsLayout/ContentsLayout';
+import TabMenu from '../.././components/common/TabMenu/TabMenu';
+import Button from '../../components/common/Button/Button';
+import Post from '../../components/common/Post/Post';
+import { EMPTY_FEED_IMAGE } from '../.././styles/CommonImages';
+
+const FeedPage = () => {
+  const [isFollowingPost, setIsFollowingPost] = useState(true);
+
+  return (
+    <>
+      <TopMainNav title={'가져도댕냥 피드'} />
+      <ContentsLayout isTabMenu={true}>
+        {isFollowingPost ? (
+          <MainFeedStyle>
+            <Post userName='' userId='' />
+            <Post userName='' userId='' />
+          </MainFeedStyle>
+        ) : (
+          <EmptyFeedStyle>
+            <ErrorImg src={EMPTY_FEED_IMAGE} alt='' />
+            <span>유저를 검색해 팔로우 해보세요!</span>
+            <Button size='M'>검색하기</Button>
+          </EmptyFeedStyle>
+        )}
+      </ContentsLayout>
+      <TabMenu />
+    </>
+  );
+};
+
+export default FeedPage;
+
+const MainFeedStyle = styled.main``;
+
+const EmptyFeedStyle = styled.main`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 50vh auto 0;
+  transform: translateY(-50%);
+
+  & span {
+    margin-top: 2em;
+    margin-bottom: 2em;
+    font-size: 1.4em;
+    color: var(--sub-text-color);
+  }
+`;
+
+const ErrorImg = styled.img`
+  width: 160px;
+`;

--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -9,25 +9,25 @@ import Post from '../../components/common/Post/Post';
 import { EMPTY_FEED_IMAGE } from '../.././styles/CommonImages';
 
 const FeedPage = () => {
-  const [isFollowingPost, setIsFollowingPost] = useState(true);
+  const [isFollowingPost, setIsFollowingPost] = useState(false);
 
   return (
     <>
       <TopMainNav title={'가져도댕냥 피드'} />
-      <ContentsLayout isTabMenu={true}>
-        {isFollowingPost ? (
+      {isFollowingPost ? (
+        <ContentsLayout>
           <MainFeedStyle>
             <Post userName='' userId='' />
             <Post userName='' userId='' />
           </MainFeedStyle>
-        ) : (
-          <EmptyFeedStyle>
-            <ErrorImg src={EMPTY_FEED_IMAGE} alt='' />
-            <span>유저를 검색해 팔로우 해보세요!</span>
-            <Button size='M'>검색하기</Button>
-          </EmptyFeedStyle>
-        )}
-      </ContentsLayout>
+        </ContentsLayout>
+      ) : (
+        <EmptyFeedStyle>
+          <ErrorImg src={EMPTY_FEED_IMAGE} alt='' />
+          <span>유저를 검색해 팔로우 해보세요!</span>
+          <Button size='M'>검색하기</Button>
+        </EmptyFeedStyle>
+      )}
       <TabMenu />
     </>
   );


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 팀원분들께서 작업해주신 컴포넌트를 합쳐 전체 페이지 세부 Style을 수정했습니다. 

## 기대 결과
- useState 사용하여 팔로잉한 사람들이 게시물을 가지고 있을때 (true일때) 는 피드 리스트가 나오게 구현했고, 반대의 경우(false) 빈 페이지가 뜨게 구현했습니다.
- 페이지 내 아이콘이 정 가운데에 위치하게 하기 위해 빈 페이지일때는 `<ContentsLayout>`을 사용하지 않았습니다


## 스크린샷
<img width="396" alt="image" src="https://user-images.githubusercontent.com/96304623/207492103-3da7a6bf-34b4-480f-8781-93327a4c52d4.png">
<img width="393" alt="image" src="https://user-images.githubusercontent.com/96304623/207493255-1b6d81f9-88c0-4e25-a997-7e817915b97c.png">



## 관련 이슈 번호
close : #38 
