### PR TITLE
design: 팔로우 목록 페이지 퍼블리싱 (#46)

### DIFF
--- a/src/pages/FollowListPage/FollowListPage.jsx
+++ b/src/pages/FollowListPage/FollowListPage.jsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import TopTitleNav from '../../components/common/TopNavBar/TopTitleNav';
+import TabMenu from '../../components/common/TabMenu/TabMenu';
+import ContentsLayout from '../../components/layout/ContentsLayout/ContentsLayout';
+import Follow from '../../components/common/userItem/Follow/Follow';
+import styled from 'styled-components';
+
+const FollowListPage = () => {
+  return (
+    <>
+      <TopTitleNav title='Followers' />
+      <ContentsLayout padding='2.4rem 1.6rem'>
+        <FollowList>
+          <Follow />
+          <Follow />
+          <Follow />
+          <Follow />
+          <Follow />
+          <Follow />
+          <Follow />
+        </FollowList>
+      </ContentsLayout>
+      <TabMenu />
+    </>
+  );
+};
+
+export default FollowListPage;
+
+const FollowList = styled.ul`
+  & > li:not(:last-of-type) {
+    margin-bottom: 16px;
+  }
+`;


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 팔로우 목록 페이지를 구현했습니다.


## 기대 결과
- 팔로우 목록이 뜨도록 구현했습니다.


## 리뷰어에게 전달 사항
- 팔로워 목록 페이지, 팔로잉 목록 페이지는 UI가 동일하므로 본 페이지를 재사용할 예정입니다.


## 스크린샷
![스크린샷 2022-12-14 오후 1 55 07](https://user-images.githubusercontent.com/105365737/207509314-a85f95db-00c9-4fd7-9949-04dc960472c1.png)


## 관련 이슈 번호
close : #46  
