### PR TITLE
design: 게시물 상세 페이지 퍼블리싱 (#78)

### DIFF
--- a/src/components/common/Comment/Comment.jsx
+++ b/src/components/common/Comment/Comment.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import ProfileImage from '../ProfileImage/ProfileImage';
 import { PROFILE1_IMAGE, PROFILE2_IMAGE } from '../../../styles/CommonImages';
@@ -9,13 +9,26 @@ const Comment = () => {
     <CommentForm>
       <ProfileImage src={PROFILE1_IMAGE} alt='프로필 이미지'></ProfileImage>
       <input type='text' placeholder='댓글 입력하기...' />
-      <button>게시</button>
+      <Button disabled={true}>게시</Button>
     </CommentForm>
   );
 };
 
 export default Comment;
 
+const colorStyles = css`
+  ${(props) =>
+    props.disabled === false &&
+    css`
+      color: var(--login-bg-color);
+    `}
+`;
+const Button = styled.button`
+  font-size: 1.4em;
+  color: var(--chat-border-color);
+  ${colorStyles}
+  font-weight: 500;
+`;
 const CommentForm = styled.form`
   position: fixed;
   bottom: 0;
@@ -25,22 +38,19 @@ const CommentForm = styled.form`
   width: 390px;
   height: 61px;
   padding: 1.3rem 1.6rem;
-
+  background: #fff;
+  border-top: 1px solid var(--border-color);
   & input {
     font-size: 1.4em;
     height: 36px;
     flex-grow: 1;
     padding: 0.2rem;
     margin-left: 1.6rem;
+    outline: none;
+    color: #000;
   }
 
   & input::placeholder {
     color: var(--chat-border-color);
-  }
-
-  & button {
-    font-size: 1.4em;
-    color: var(--chat-border-color);
-    font-weight: 500;
   }
 `;

--- a/src/pages/PostDetailPage/PostComment.jsx
+++ b/src/pages/PostDetailPage/PostComment.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import { PROFILE1_IMAGE, PROFILE2_IMAGE } from '../../styles/CommonImages';
+import { MORE_SMALL_ICON } from '../../styles/CommonIcons';
+const PostComment = () => {
+  return (
+    <>
+      <CommentItem>
+        <AuthorInfo>
+          <Link to='/'>
+            <ProfileImg src={PROFILE1_IMAGE} alt='프로필 이미지' />
+          </Link>
+          <Link to='/'>
+            <strong>testID</strong>
+          </Link>
+          <span>3주전</span>
+        </AuthorInfo>
+        <CommentText>테스트 텍스트입니다.</CommentText>
+        <MoreButton />
+      </CommentItem>
+    </>
+  );
+};
+
+export default PostComment;
+
+const CommentItem = styled.li`
+  position: relative;
+  margin-bottom: 1.6rem;
+`;
+
+const AuthorInfo = styled.div`
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 0.4rem;
+  span {
+    margin-top: 0.85rem;
+    font-weight: 400;
+    font-size: 1rem;
+    line-height: 1.3rem;
+    color: #767676;
+    ::before {
+      content: '·';
+      margin-right: 0.4rem;
+    }
+  }
+  strong {
+    font-weight: 500;
+    font-size: var(--fs-md);
+    line-height: 1.8rem;
+  }
+  a:nth-child(1) {
+    margin: 0 1.2rem 0 0;
+  }
+  a:nth-child(2) {
+    margin: 0.6rem 0.6rem 0 0;
+  }
+`;
+
+const CommentText = styled.p`
+  padding-left: 4.8rem;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  font-size: 400;
+  color: #333333;
+`;
+
+const MoreButton = styled.button`
+  content: '';
+  position: absolute;
+  top: 0.5rem;
+  right: 0;
+  width: 2rem;
+  height: 2rem;
+  background-image: url(${MORE_SMALL_ICON});
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+`;
+
+const ProfileImg = styled.img`
+  width: 3.6rem;
+  height: 3.6rem;
+`;

--- a/src/pages/PostDetailPage/PostDetailPage.jsx
+++ b/src/pages/PostDetailPage/PostDetailPage.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import TopBasicNav from '../../components/common/TopNavBar/TopBasicNav';
+import Comment from '../../components/common/Comment/Comment';
+import ContentsLayout from '../../components/layout/ContentsLayout/ContentsLayout';
+import Post from '../../components/common/Post/Post';
+import styled from 'styled-components';
+import PostComment from './PostComment';
+
+const PostDetailPage = () => {
+  return (
+    <ContentsLayout isTabMenu={true} padding='2rem 0 0 0'>
+      <TopBasicNav />
+      <PostViewer>
+        <h2 className='sr-only'>Post Item</h2>
+        <Post userName={'Test'} userId={'@test'} />
+      </PostViewer>
+      <PostCommentList>
+        <h2 className='sr-only'>PostComment</h2>
+        <PostComment />
+        <PostComment />
+        <PostComment />
+        <PostComment />
+      </PostCommentList>
+      <Comment />
+    </ContentsLayout>
+  );
+};
+
+export default PostDetailPage;
+
+const PostViewer = styled.section`
+  height: auto;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--border-color);
+`;
+
+const PostCommentList = styled.ul`
+  height: auto;
+  margin-top: 2rem;
+  margin-left: 1.2rem;
+  margin-right: 2rem;
+`;


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 게시물 상세 페이지 UI 를 렌더링 하기위해서 퍼블리싱을 하였다.


## 기대 결과
- 게시물 상세 페이지가 피그마 시안에 맞추어 렌더링 될 것이다.


## 리뷰어에게 전달 사항
- 확인부탁드려요오~

## 스크린샷
![게시물상세페이지](https://user-images.githubusercontent.com/57481378/207541570-0027b7c9-e960-4ae5-a377-ac4d448a38f7.png)



## 관련 이슈 번호
close : #78 
