### PR TITLE
design: Pagination Carousel 컴포넌트 구현 (#91)

### DIFF
--- a/src/components/carousel/PaginationCarousel/PaginationCarousel.jsx
+++ b/src/components/carousel/PaginationCarousel/PaginationCarousel.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import SwiperCore, { Pagination, Autoplay } from 'swiper';
+import { Pagination, Autoplay } from 'swiper';
 import 'swiper/css';
 import 'swiper/css/pagination';
 

--- a/src/components/carousel/PaginationCarousel/PaginationCarousel.jsx
+++ b/src/components/carousel/PaginationCarousel/PaginationCarousel.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import SwiperCore, { Pagination, Autoplay } from 'swiper';
+import 'swiper/css';
+import 'swiper/css/pagination';
+
+const PaginationCarousel = ({ itemList }) => {
+  return (
+    <>
+      <Swiper
+        modules={[Autoplay, Pagination]}
+        pagination={{
+          dynamicBullets: true,
+        }}
+        loop='true'
+        autoplay={{ delay: 2500, disableOnInteraction: false }}
+      >
+        {itemList.map(({ id, src, alt }) => (
+          <SwiperSlide key={id}>
+            <img src={src} alt={alt} />
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </>
+  );
+};
+
+export default PaginationCarousel;


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 페이지네이션 캐러셀을 만들었습니다.


## 기대 결과
- 2.5초마다 자동으로 페이지가 넘어가는 캐러셀을 사용할 수 있습니다.
- 마우스로 직접 페이지를 넘길수도 있습니다.


## 스크린샷
![Dec-14-2022 18-41-28](https://user-images.githubusercontent.com/105365737/207560943-0cc95bcb-c718-4201-b850-25653b1c45c1.gif)


## 관련 이슈 번호
close : #91 
