### PR TITLE
design: ProfileImage 컴포넌트 스타일 커스텀 기능 추가 (#93)

### DIFF
--- a/src/components/common/ProfileImage/ProfileImage.jsx
+++ b/src/components/common/ProfileImage/ProfileImage.jsx
@@ -4,9 +4,10 @@ import styled from 'styled-components';
 // * 사용법 - 아래의 3가지 props를 전달해줘야 합니다 *
 // src : 프로필 이미지 경로
 // alt : 프로필 이미지에 대한 설명 (생략시 기본값: '')
-// width : 프로필 이미지의 width size (px은 제외하고 전달해야 합니다 / 생략시 기본값: 36)
-const ProfileImage = ({ src, alt = '', width = '36' }) => {
-  return <Image src={src} alt={alt} width={width} />;
+// width : 프로필 이미지의 width size (단위는 px / 생략시 기본값: 36)
+// borderSize : 프로필 이미지의 테두리 굵기 (단위는 px / 생략시 기본값 : 2)
+const ProfileImage = ({ src, alt = '', width = '36', borderWeight = '2' }) => {
+  return <Image src={src} alt={alt} width={width} borderWeight={borderWeight} />;
 };
 
 export default ProfileImage;
@@ -14,6 +15,6 @@ export default ProfileImage;
 const Image = styled.img`
   width: ${(props) => props.width}px;
   height: auto;
-  border: 2px solid var(--profile-border-color);
+  border: ${(props) => props.borderWeight}px solid var(--profile-border-color);
   border-radius: 50%;
 `;

--- a/src/components/common/ProfileImage/ProfileImage.jsx
+++ b/src/components/common/ProfileImage/ProfileImage.jsx
@@ -5,16 +5,18 @@ import styled from 'styled-components';
 // src : 프로필 이미지 경로
 // alt : 프로필 이미지에 대한 설명 (생략시 기본값: '')
 // width : 프로필 이미지의 width size (단위는 px / 생략시 기본값: 36)
-// borderSize : 프로필 이미지의 테두리 굵기 (단위는 px / 생략시 기본값 : 2)
-const ProfileImage = ({ src, alt = '', width = '36', borderWeight = '2' }) => {
-  return <Image src={src} alt={alt} width={width} borderWeight={borderWeight} />;
+// borderSize : 프로필 이미지의 테두리 굵기 (단위는 px / 생략시 기본값 : 0.5)
+// isPointer : 마우스 커서를 포인터로 할지, 디폴트로 할지 (생략시 기본값 : 포인터로 적용)
+const ProfileImage = ({ src, alt = '', width = '36', borderWeight = '0.5', isPointer = 'true' }) => {
+  return <Image src={src} alt={alt} width={width} borderWeight={borderWeight} isPointer={isPointer} />;
 };
 
 export default ProfileImage;
 
 const Image = styled.img`
   width: ${(props) => props.width}px;
-  height: auto;
+  height: ${(props) => props.width}px;
   border: ${(props) => props.borderWeight}px solid var(--profile-border-color);
   border-radius: 50%;
+  cursor: ${(props) => (props.isPointer ? 'pointer' : 'default')};
 `;

--- a/src/components/common/ProfileImage/ProfileImage.jsx
+++ b/src/components/common/ProfileImage/ProfileImage.jsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 // alt : 프로필 이미지에 대한 설명 (생략시 기본값: '')
 // width : 프로필 이미지의 width size (단위는 px / 생략시 기본값: 36)
 // borderSize : 프로필 이미지의 테두리 굵기 (단위는 px / 생략시 기본값 : 0.5)
-// isPointer : 마우스 커서를 포인터로 할지, 디폴트로 할지 (생략시 기본값 : 포인터로 적용)
+// isPointer : 마우스 커서를 포인터로 할지, 디폴트로 할지 (boolean 값으로 전달해야함 / 생략시 기본값 : 포인터로 적용)
 const ProfileImage = ({ src, alt = '', width = '36', borderWeight = '0.5', isPointer = 'true' }) => {
   return <Image src={src} alt={alt} width={width} borderWeight={borderWeight} isPointer={isPointer} />;
 };


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 확장성을 위해 ProfileImage의 스타일 커스텀 기능을 추가했습니다.
- height: auto에서 문제가 있어 height를 width size와 동일한 px로 적용하도록 했습니다.


## 기대 결과
- height가 width의 사이즈와 동일하게 적용됩니다.
- border의 기본값이 0.5px로 변경됩니다.
- borderWeight 값을 전달해서 테두리 굵기 커스텀이 가능합니다.
- isPointer를 전달해서 마우스 커서를 포인터로 할지, 디폴트로 할지 설정이 가능합니다.


## 리뷰어에게 전달 사항
- isPointer는 boolean 값으로 전달해야 하며 기본값은 `true(포인터 커서)`입니다.
- isPointer 값이 true일 경우 포인터 커서로, false일 경우 디폴트 커서로 적용됩니다.


## 관련 이슈 번호
close : #93 
