### PR TITLE
design: 커뮤니티 날씨 페이지 퍼블리싱 (#95)

### DIFF
--- a/src/pages/communityPage/CommunityWeatherPage/CommunityWeatherPage.jsx
+++ b/src/pages/communityPage/CommunityWeatherPage/CommunityWeatherPage.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import CommunityLayout from '../CommunityLayout';
+import NotFoundLocation from '../NotFoundLocation';
+import DetailWeatherInfo from './DetailWeatherInfo';
+import SummaryWeatherInfo from './SummaryWeatherInfo';
+
+const CommunityWeatherPage = () => {
+  const [getLocation, setGetLocation] = useState(true);
+  const [walkLevel, setWalkLevel] = useState(10);
+  const walkTextList = [
+    { id: 0, text: '산책하기 좋은 날' },
+    { id: 1, text: '옷 입고 나가자' },
+    { id: 2, text: '공기가 안 좋아' },
+  ];
+
+  return (
+    <CommunityLayout>
+      <WeatherSection>
+        {getLocation ? (
+          <>
+            <h2 className='sr-only'>실시간 날씨 정보</h2>
+            <SummaryWeatherInfo walkLevel={walkLevel} walkTextList={walkTextList} />
+            <DetailWeatherInfo />
+          </>
+        ) : (
+          <NotFoundLocation />
+        )}
+      </WeatherSection>
+    </CommunityLayout>
+  );
+};
+
+export default CommunityWeatherPage;
+
+const WeatherSection = styled.section`
+  border-top: 1px solid var(--border-color);
+`;

--- a/src/pages/communityPage/CommunityWeatherPage/CommunityWeatherPage.jsx
+++ b/src/pages/communityPage/CommunityWeatherPage/CommunityWeatherPage.jsx
@@ -1,18 +1,13 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import CommunityLayout from '../CommunityLayout';
-import NotFoundLocation from '../NotFoundLocation';
 import DetailWeatherInfo from './DetailWeatherInfo';
 import SummaryWeatherInfo from './SummaryWeatherInfo';
 
 const CommunityWeatherPage = () => {
   const [getLocation, setGetLocation] = useState(true);
-  const [walkLevel, setWalkLevel] = useState(10);
-  const walkTextList = [
-    { id: 0, text: '산책하기 좋은 날' },
-    { id: 1, text: '옷 입고 나가자' },
-    { id: 2, text: '공기가 안 좋아' },
-  ];
+  const [walkScore, setWalkScore] = useState(8);
+  const walkTextList = ['산책하기 좋은 날', '짧은 산책을 추천해요', '이불 속이 안전해'];
 
   return (
     <CommunityLayout>
@@ -20,11 +15,11 @@ const CommunityWeatherPage = () => {
         {getLocation ? (
           <>
             <h2 className='sr-only'>실시간 날씨 정보</h2>
-            <SummaryWeatherInfo walkLevel={walkLevel} walkTextList={walkTextList} />
+            <SummaryWeatherInfo walkScore={walkScore} walkTextList={walkTextList} />
             <DetailWeatherInfo />
           </>
         ) : (
-          <NotFoundLocation />
+          <></>
         )}
       </WeatherSection>
     </CommunityLayout>

--- a/src/pages/communityPage/CommunityWeatherPage/DetailWeatherInfo.jsx
+++ b/src/pages/communityPage/CommunityWeatherPage/DetailWeatherInfo.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const DetailWeatherInfo = () => {
+  return (
+    <DetailInfoWrapper>
+      <WeatherList>
+        <CurrentTempWrapper>
+          <dt className='sr-only'>현재 기온</dt>
+          <CurrentTemp>
+            -2<span className='sr-only'>도</span>
+          </CurrentTemp>
+        </CurrentTempWrapper>
+        <HighLowTempWrapper>
+          <dt className='sr-only'>최고/최저 기온</dt>
+          <HightTemp aria-label='최고 기온'>
+            6<span className='sr-only'>도</span>
+          </HightTemp>
+          <LowTemp aria-label='최저 기온'>
+            -4<span className='sr-only'>도</span>
+          </LowTemp>
+        </HighLowTempWrapper>
+        <FineDustWrapper>
+          <dt>미세먼지</dt>
+          <dd>좋음</dd>
+        </FineDustWrapper>
+        <UltraFineDustWrapper>
+          <dt>초미세먼지</dt>
+          <dd>좋음</dd>
+        </UltraFineDustWrapper>
+      </WeatherList>
+    </DetailInfoWrapper>
+  );
+};
+
+export default DetailWeatherInfo;
+
+const DetailInfoWrapper = styled.div`
+  padding: 5.3rem 3.5rem;
+  border-top: 1px solid var(--border-color);
+`;
+
+const WeatherList = styled.dl`
+  display: grid;
+  grid-template-areas: 'currentTemp HighLowTemp' 'FindDust UltraFindDust';
+  grid-row-gap: 3rem;
+`;
+
+const CurrentTempWrapper = styled.div`
+  grid-area: currentTemp;
+`;
+
+const CurrentTemp = styled.dd`
+  font-size: 4.8rem;
+
+  &::after {
+    content: '°';
+  }
+`;
+
+const HighLowTempWrapper = styled.div`
+  grid-area: HighLowTemp;
+  display: flex;
+  justify-content: flex-end;
+  font-size: var(--fs-lg);
+  text-align: right;
+
+  & dd::after {
+    content: '°';
+  }
+`;
+
+const HightTemp = styled.dd`
+  padding-right: 2rem;
+  margin-right: 2rem;
+  border-right: 2px solid var(--sub-text-color);
+
+  &::before {
+    display: block;
+    content: 'max';
+    color: var(--sub-text-color);
+    margin-bottom: 1.4rem;
+  }
+`;
+
+const LowTemp = styled.dd`
+  &::before {
+    display: block;
+    content: 'min';
+    color: var(--sub-text-color);
+    margin-bottom: 1.4rem;
+  }
+`;
+
+const FineDustWrapper = styled.div`
+  grid-area: FindDust;
+  display: flex;
+  font-size: var(--fs-md);
+
+  & dt::after {
+    content: ':';
+    padding: 0 0.3rem;
+  }
+`;
+
+const UltraFineDustWrapper = styled.div`
+  grid-area: UltraFindDust;
+  display: flex;
+  justify-content: flex-end;
+  font-size: var(--fs-md);
+
+  & dt::after {
+    content: ':';
+    padding: 0 0.3rem;
+  }
+`;

--- a/src/pages/communityPage/CommunityWeatherPage/SummaryWeatherInfo.jsx
+++ b/src/pages/communityPage/CommunityWeatherPage/SummaryWeatherInfo.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import styled from 'styled-components';
+import { WALK_ABLE_IMAGE, WALK_DISABLE_IMAGE } from '../../../styles/CommonImages';
+
+const SummaryWeatherInfo = ({ walkLevel, walkTextList }) => {
+  return (
+    <SummaryInfoWrapper>
+      <SummaryInfo>
+        <Date dateTime='2022-11-06'>2022년 11월 6일</Date>
+        <Location>제주도 제주시 무슨읍</Location>
+        <CurrentWeather>구름 많음</CurrentWeather>
+      </SummaryInfo>
+      <div>
+        <WalkImage src={walkLevel <= 50 ? WALK_ABLE_IMAGE : WALK_DISABLE_IMAGE} alt='' />
+        <WalkText>
+          <WalkLevel>
+            산책 난이도 : <em>{walkLevel}%</em>
+          </WalkLevel>
+          <WalkDescription>{walkTextList[0].text}</WalkDescription>
+        </WalkText>
+      </div>
+    </SummaryInfoWrapper>
+  );
+};
+
+export default SummaryWeatherInfo;
+
+const SummaryInfoWrapper = styled.div`
+  padding: 5.3rem 3.5rem;
+  text-align: center;
+`;
+
+const SummaryInfo = styled.div`
+  margin-bottom: 5rem;
+`;
+
+const Date = styled.time`
+  display: block;
+  margin-bottom: 3rem;
+  font-size: var(--fs-lg);
+  color: var(--sub-text-color);
+`;
+
+const Location = styled.strong`
+  display: block;
+  margin-bottom: 1.3rem;
+  font-size: 2.2rem;
+  font-weight: 500;
+`;
+
+const CurrentWeather = styled.p`
+  font-size: 2rem;
+  color: #3f3f3f;
+`;
+
+const WalkImage = styled.img`
+  width: 165px;
+  height: auto;
+  margin: 0 auto 2rem;
+`;
+
+const WalkText = styled.div`
+  padding: 2.2rem 1.2rem;
+  border-radius: 5px;
+  box-shadow: rgba(0, 0, 0, 0.08) 0px 6px 24px 0px, rgba(0, 0, 0, 0.08) 0px 0px 0px 1px;
+`;
+
+const WalkLevel = styled.strong`
+  display: block;
+  margin-bottom: 2rem;
+  font-size: 2rem;
+  font-weight: 500;
+
+  & em {
+    color: var(--login-bg-color);
+  }
+`;
+
+const WalkDescription = styled.p`
+  font-size: var(--fs-xl);
+`;

--- a/src/pages/communityPage/CommunityWeatherPage/SummaryWeatherInfo.jsx
+++ b/src/pages/communityPage/CommunityWeatherPage/SummaryWeatherInfo.jsx
@@ -14,9 +14,9 @@ const SummaryWeatherInfo = ({ walkLevel, walkTextList }) => {
         <WalkImage src={walkLevel <= 50 ? WALK_ABLE_IMAGE : WALK_DISABLE_IMAGE} alt='' />
         <WalkText>
           <WalkLevel>
-            산책 난이도 : <em>{walkLevel}%</em>
+            산책 난이도 : <em>{walkLevel}점</em>
           </WalkLevel>
-          <WalkDescription>{walkTextList[0].text}</WalkDescription>
+          <WalkDescription>{walkTextList[2].text}</WalkDescription>
         </WalkText>
       </div>
     </SummaryInfoWrapper>

--- a/src/pages/communityPage/CommunityWeatherPage/SummaryWeatherInfo.jsx
+++ b/src/pages/communityPage/CommunityWeatherPage/SummaryWeatherInfo.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { WALK_ABLE_IMAGE, WALK_DISABLE_IMAGE } from '../../../styles/CommonImages';
 
-const SummaryWeatherInfo = ({ walkLevel, walkTextList }) => {
+const SummaryWeatherInfo = ({ walkScore, walkTextList }) => {
   return (
     <SummaryInfoWrapper>
       <SummaryInfo>
@@ -11,12 +11,14 @@ const SummaryWeatherInfo = ({ walkLevel, walkTextList }) => {
         <CurrentWeather>구름 많음</CurrentWeather>
       </SummaryInfo>
       <div>
-        <WalkImage src={walkLevel <= 50 ? WALK_ABLE_IMAGE : WALK_DISABLE_IMAGE} alt='' />
+        <WalkImage src={walkScore <= 8 ? WALK_ABLE_IMAGE : WALK_DISABLE_IMAGE} alt='' />
         <WalkText>
-          <WalkLevel walkLevel={walkLevel}>
-            산책 난이도 : <em>{walkLevel}점</em>
+          <WalkLevel walkScore={walkScore}>
+            산책 난이도 : <em>{walkScore >= 8 ? '어려움' : walkScore >= 5 ? '보통' : '쉬움'}</em>
           </WalkLevel>
-          <WalkDescription>{walkTextList[2].text}</WalkDescription>
+          <WalkDescription>
+            {walkScore >= 8 ? walkTextList[2] : walkScore >= 5 ? walkTextList[1] : walkTextList[0]}
+          </WalkDescription>
         </WalkText>
       </div>
     </SummaryInfoWrapper>
@@ -72,7 +74,7 @@ const WalkLevel = styled.strong`
   font-weight: 500;
 
   & em {
-    color: ${(props) => (props.walkLevel >= 60 ? 'var(--alert-color)' : 'var(--login-bg-color)')};
+    color: ${(props) => (props.walkScore >= 8 ? '#eb5757' : props.walkScore >= 5 ? '#766eeb' : '#0280ff')};
   }
 `;
 

--- a/src/pages/communityPage/CommunityWeatherPage/SummaryWeatherInfo.jsx
+++ b/src/pages/communityPage/CommunityWeatherPage/SummaryWeatherInfo.jsx
@@ -11,7 +11,7 @@ const SummaryWeatherInfo = ({ walkScore, walkTextList }) => {
         <CurrentWeather>구름 많음</CurrentWeather>
       </SummaryInfo>
       <div>
-        <WalkImage src={walkScore <= 8 ? WALK_ABLE_IMAGE : WALK_DISABLE_IMAGE} alt='' />
+        <WalkImage src={walkScore >= 8 ? WALK_DISABLE_IMAGE : WALK_ABLE_IMAGE} alt='' />
         <WalkText>
           <WalkLevel walkScore={walkScore}>
             산책 난이도 : <em>{walkScore >= 8 ? '어려움' : walkScore >= 5 ? '보통' : '쉬움'}</em>

--- a/src/pages/communityPage/CommunityWeatherPage/SummaryWeatherInfo.jsx
+++ b/src/pages/communityPage/CommunityWeatherPage/SummaryWeatherInfo.jsx
@@ -13,7 +13,7 @@ const SummaryWeatherInfo = ({ walkLevel, walkTextList }) => {
       <div>
         <WalkImage src={walkLevel <= 50 ? WALK_ABLE_IMAGE : WALK_DISABLE_IMAGE} alt='' />
         <WalkText>
-          <WalkLevel>
+          <WalkLevel walkLevel={walkLevel}>
             산책 난이도 : <em>{walkLevel}점</em>
           </WalkLevel>
           <WalkDescription>{walkTextList[2].text}</WalkDescription>
@@ -72,7 +72,7 @@ const WalkLevel = styled.strong`
   font-weight: 500;
 
   & em {
-    color: var(--login-bg-color);
+    color: ${(props) => (props.walkLevel >= 60 ? 'var(--alert-color)' : 'var(--login-bg-color)')};
   }
 `;
 


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 커뮤니티 날씨 페이지를 구현했습니다.


## 기대 결과
- 커뮤니티 날씨 페이지 화면 완성


## 리뷰어에게 전달 사항
- border, img 사이즈, box-shadow에는 일부러 px 단위를 적용했습니다.
- 제가 만든 시안이 맘에 안들어서 수정하면서 하느라 시간이 좀 걸렸습니다 🥲
- ~산책 난이도라는 개념을 도입하고 `10점(쉬움) ~ 100점(어려움)`으로 나타내려고 해요!~
- ~산책 난이도 10점 ~ 50점에선 댕그리가 웃고, 60점 ~ 100점에선 댕그리가 우는 이미지를 보여주려고 합니다.~

- 피드백을 받아 난이도를 쉬움, 보통, 어려움으로 수정했습니다.
```
* 기온 / 비,눈 / 미세먼지 지수 이렇게 3개의 큰 그룹으로 나눈다.
* 기온, 미세먼지 그룹은 각 기준을 둬서 상(안좋음) / 중 / 하(좋음)를 평가한다.
* 비,눈 그룹은 상(폭설,폭우일때), 중(평범할때), 하(안올때)로 평가한다.
* 상은 3점, 중은 2점, 하는 1점의 점수를 갖는다.
* 세 그룹의 난이도를 종합해서 평가한다.
* 예를 들어 기온 - 상, 폭우 - 상, 미세먼지 - 하라면..? 3 + 3 + 1 = 7점

* 최종 산책 난이도 측정 기준
    * 어려움 : 8~9점
    * 보통 : 5~7점
    * 쉬움 : 3~4점
```


## 스크린샷
<img width="1772" alt="무제 2" src="https://user-images.githubusercontent.com/105365737/207803982-2c36f7b6-f490-4cfd-b235-15d2af203f06.png">
- 보통이나 쉬움 버전 댕그리를 하나 더 그려야겠네요 😀


## 관련 이슈 번호
close : #95 
