### PR TITLE
design: 리스트 아이템을 받아 HiddenMenu를 구성할 수 있도록 컴포넌트 확장 (#120)

### DIFF
--- a/src/components/common/HiddenMenu/HiddenMenu.jsx
+++ b/src/components/common/HiddenMenu/HiddenMenu.jsx
@@ -5,10 +5,28 @@ import Alert from '../Alert/Alert';
 import { fadeIn } from '../Animation/Animation';
 
 // * 주의 *
-// 백그라운드 클릭 시 히든메뉴리스트를 닫기 위해서는 부모에게 onClickHandler 함수를 받아야 합니다.
-// 부모로부터 받은 onClickHandler 함수가 없다면 39~41번째 줄에서 사용중인 함수가 없어 백그라운드 클릭시 'onClick is not a function' 에러가 발생합니다.
-// 부모에 추가할 onClickHandler 함수 예시는 본 파일 최하단에 있습니다.
-const HiddenMenu = ({ onClick }) => {
+// 1. 백그라운드 클릭 시 히든메뉴리스트를 닫기 위해서는 부모에게 onClickHandler 함수를 받아야 합니다.
+//  - 부모로부터 받은 onClickHandler 함수가 없다면 39~41번째 줄에서 사용중인 함수가 없어 백그라운드 클릭시 'onClick is not a function' 에러가 발생합니다.
+//
+// 2. 히든메뉴 사용을 위해 아래와 같은 형식의 리스트를 만들어 props로 전달해줘야 합니다.
+// [예]
+// const filterList = [
+//   { id: 0, title: '5km 이내', type: 'button', isConnectAlert: false, to: '' },
+//   { id: 1, title: '10km 이내', type: 'button', isConnectAlert: false, to: '' },
+//   { id: 2, title: '20km 이내', type: 'button', isConnectAlert: false, to: '' },
+//   { id: 3, title: '30km 이내', type: 'link', isConnectAlert: true, to: '/test' },
+// ];
+// <HiddenMenu onClick={onClickHiddenMenuButtonHandler} itemList={filterList} />
+//
+// [옵션 설명]
+//  - id : key로 사용할 unique한 id
+//  - title : 리스트에 들어갈 제목
+//  - type : 아이템의 타입 (button, link 두 종류)
+//  - isConnectAlert : button 타입일 때 Alert 컴포넌트와 연결할지 여부 (boolean값으로 전달해야 함) / link 타입인 경우에는 false 값으로 작성
+//  - to : link 타입일 때 연결될 주소 / button 타입인 경우에는 빈 문자열로 작성
+//
+// ***** 본 파일 하단에 부모 컴포넌트에 추가할 내용에 대한 전체 예시가 있습니다 *****
+const HiddenMenu = ({ onChangeHiddenMenuState, itemList = [] }) => {
   const backgroundRef = useRef(null);
   const [isOpenAlert, setIsOpenAlert] = useState(false);
 
@@ -31,13 +49,13 @@ const HiddenMenu = ({ onClick }) => {
     };
   }, []);
 
-  const onClickHiddenMenuHandler = (e) => {
+  const onChangeHiddenMenuStateHandler = (e) => {
     if (isOpenAlert) {
       return;
     }
 
     if (e.target === backgroundRef.current) {
-      onClick(false);
+      onChangeHiddenMenuState(false);
     }
   };
 
@@ -50,17 +68,19 @@ const HiddenMenu = ({ onClick }) => {
       <section>
         <h2 className='sr-only'>메뉴</h2>
 
-        <MenuWrapper ref={backgroundRef} onClick={onClickHiddenMenuHandler}>
+        <MenuWrapper ref={backgroundRef} onClick={onChangeHiddenMenuStateHandler}>
           <MenuList isOpenAlert={isOpenAlert}>
-            <MenuItem>
-              <button onClick={onClickAlertButtonHandler}>삭제</button>
-            </MenuItem>
-            <MenuItem>
-              <button>수정</button>
-            </MenuItem>
-            <MenuItem>
-              <Link to='#'>웹사이트에서 상품보기</Link>
-            </MenuItem>
+            {itemList.map(({ id, title, type, isConnectAlert, to }) => (
+              <MenuItem key={id}>
+                {type === 'button' ? (
+                  <button onClick={isConnectAlert ? onClickAlertButtonHandler : null}>{title}</button>
+                ) : type === 'link' ? (
+                  <Link to={to}>{title}</Link>
+                ) : (
+                  <></>
+                )}
+              </MenuItem>
+            ))}
           </MenuList>
         </MenuWrapper>
       </section>
@@ -119,20 +139,32 @@ const MenuItem = styled.li`
 `;
 
 // 히든메뉴리스트를 닫기 위해 부모에 추가할 onClickHandler 함수 예시 시작 //
+// const filterList = [
+//   { id: 0, title: '5km 이내', type: 'button', isConnectAlert: false, to: '' },
+//   { id: 1, title: '10km 이내', type: 'button', isConnectAlert: true, to: '' },
+//   { id: 2, title: '20km 이내', type: 'button', isConnectAlert: false, to: '' },
+//   { id: 3, title: '30km 이내', type: 'link', isConnectAlert: false, to: '/test' },
+// ];
 // const [isShowHiddenMenu, setIsShowHiddenMenu] = useState(false);
-// const onClickHiddenMenuButtonHandler = () => {
+// const onChangeHiddenMenuStateHandler = () => {
 //   setIsShowHiddenMenu(!isShowHiddenMenu);
 // };
+//
 // return (
 //   <>
-//     <button onClick={onClickHiddenMenuButtonHandler}>히든메뉴 & alert 테스트 버튼</button>
-//     {isShowHiddenMenu ? (
-//       <>
-//         <HiddenMenu onClick={onClickHiddenMenuButtonHandler} />
-//       </>
-//     ) : (
-//       <></>
-//     )}
+//     <GlobalStyle />
+//     <FrameMain>
+//       <ScreenContainer>
+//         <button onClick={onChangeHiddenMenuStateHandler}>히든메뉴 & alert 테스트 버튼</button>
+//         {isShowHiddenMenu ? (
+//           <>
+//             <HiddenMenu onChangeHiddenMenuState={onChangeHiddenMenuStateHandler} itemList={filterList} />
+//           </>
+//         ) : (
+//           <></>
+//         )}
+//       </ScreenContainer>
+//     </FrameMain>
 //   </>
 // );
 // 히든메뉴리스트를 닫기 위해 부모에 추가할 onClickHandler 함수 예시 끝 //


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 리스트 아이템을 개발자에게 직접 받아 HiddenMenu 리스트를 구성할 수 있도록 컴포넌트를 확장하였습니다.


## 기대 결과
- 개발자는 HiddenMenu 컴포넌트로 아래와 같은 형식의 리스트 아이템을 전달해서 HiddenMenu 리스트를 원하는 대로 구성할 수 있습니다.
```jsx
[예]
const filterList = [
  { id: 0, title: '5km 이내', type: 'button', isConnectAlert: false, to: '' },
  { id: 1, title: '10km 이내', type: 'button', isConnectAlert: false, to: '' },
  { id: 2, title: '20km 이내', type: 'button', isConnectAlert: false, to: '' },
  { id: 3, title: '30km 이내', type: 'link', isConnectAlert: true, to: '/test' },
];
<HiddenMenu onClick={onClickHiddenMenuButtonHandler} itemList={filterList} />

[옵션 설명]
 - id : key로 사용할 unique한 id
 - title : 리스트에 들어갈 제목
 - type : 아이템의 타입 (button, link 두 종류)
 - isConnectAlert : button 타입일 때 Alert 컴포넌트와 연결할지 여부 (boolean값으로 전달해야 함) / link 타입인 경우에는 false 값으로 작성
 - to : link 타입일 때 연결될 주소 / button 타입인 경우에는 빈 문자열로 작성
```


## 리뷰어에게 전달 사항
- 사용법을 7~28 라인에 작성했습니다.
- 본 파일 최하단에 부모 컴포넌트에 추가할 내용에 대한 전체 예시가 있습니다.


## 스크린샷
- 아래처럼 구성한 리스트를 HiddenMenu 리스트로 전달했을때 화면
```jsx
const filterList = [
  { id: 0, title: '포도', type: 'button', isConnectAlert: false, to: '' }, // 타입이 button이고 얼럿창을 띄우지 않는 경우
  { id: 1, title: '딸기', type: 'button', isConnectAlert: true, to: '' }, // 타입이 button이고 얼럿창을 띄우는 경우
  { id: 2, title: '사과', type: 'link', isConnectAlert: false, to: '/applePage' }, // 타입이 link이고 /applePage로 연결한 경우
];
```

![Dec-16-2022 12-01-39](https://user-images.githubusercontent.com/105365737/208012376-17b382cf-ab05-4f77-b66d-73cb4ebdb542.gif)
- 포도 => 타입이 button이고 얼럿창을 띄우지 않는 경우이므로 클릭시 변화 없음
- 딸기 => 타입이 button이고 얼럿창을 띄우는 경우이므로 클릭시 얼럿창 출력
- 사과 => 타입이 link이고 /applePage로 연결한 경우이므로 url 변경

## 관련 이슈 번호
close : #120 
