### PR TITLE
design: TopNavBar 커스텀 (#126)

### DIFF
--- a/src/components/common/TopNavBar/TopMainNav.jsx
+++ b/src/components/common/TopNavBar/TopMainNav.jsx
@@ -4,13 +4,17 @@ import styled from 'styled-components';
 import { TopNavBar, SearchBtn } from './Styled';
 import { SEARCH_ICON } from '../../../styles/CommonIcons';
 
-const TopMainNav = ({ title }) => {
+const TopMainNav = ({ title, viewSearchBtn = true }) => {
   return (
     <TopNavBar>
       <TopNavH1>{title}</TopNavH1>
-      <SearchBtn>
-        <img src={SEARCH_ICON} alt='검색하기 버튼' />
-      </SearchBtn>
+      {viewSearchBtn ? (
+        <SearchBtn>
+          <img src={SEARCH_ICON} alt='검색하기 버튼' />
+        </SearchBtn>
+      ) : (
+        <></>
+      )}
     </TopNavBar>
   );
 };

--- a/src/components/common/TopNavBar/TopTitleNav.jsx
+++ b/src/components/common/TopNavBar/TopTitleNav.jsx
@@ -5,16 +5,20 @@ import { Link } from 'react-router-dom';
 import { TopNavBar, LeftArrow, MoreBtn } from './Styled';
 import { LEFT_ARROW_ICON, MORE_ICON } from '../../../styles/CommonIcons';
 
-const TopTitleNav = ({ title }) => {
+const TopTitleNav = ({ title, viewMoreBtn = true }) => {
   return (
     <TopNavBar>
       <Link to='/'>
         <LeftArrow src={LEFT_ARROW_ICON} alt='뒤로가기 버튼' />
       </Link>
       <TopNavH2>{title}</TopNavH2>
-      <MoreBtn>
-        <img src={MORE_ICON} alt='더보기 버튼' />
-      </MoreBtn>
+      {viewMoreBtn ? (
+        <MoreBtn>
+          <img src={MORE_ICON} alt='더보기 버튼' />
+        </MoreBtn>
+      ) : (
+        <></>
+      )}
     </TopNavBar>
   );
 };


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 디자인 시안과 동일하게 구현하기 위해 TopNav를 커스텀했습니다.


## 기대 결과
- TopTitleNav에 `viewMoreBtn={false}`를 전달하면 더보기 버튼이 보이지 않습니다. (기본값 - 더보기 버튼 보임)
- TopMainNav에 `viewSearchBtn={false}`를 전달하면 검색 버튼이 보이지 않습니다. (기본값 - 검색 버튼 보임)


## 관련 이슈 번호
close : #126 
