### PR TITLE
fix: TopNavBar style z-index 버그 수정 (#127)

### DIFF
--- a/src/components/common/TopNavBar/Styled.jsx
+++ b/src/components/common/TopNavBar/Styled.jsx
@@ -10,7 +10,7 @@ export const TopNavBar = styled.header`
   align-items: center;
   height: 48px;
   padding: 0.8em 1.2em 0.8em 1.6em;
-  z-index: 1;
+  z-index: 100;
   background-color: var(--main-bg-color);
   border-bottom: 1px solid var(--border-color);
 `;


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 상단 topNavBar 스타일 z-index 값 오류로 컨텐츠와 겹치는 상황 발생. 팀장님이 제안해주신대로 z-index 값 100으로 수정하여 해결했습니다. 

## 관련 이슈 번호
close : #127
