### PR TITLE
design: MyProfile 과 UserProfile 구분하여 ProfileHeader 구성 (#132)

### DIFF
--- a/src/pages/profilePage/ProfileHeader/MyProfileBtns.jsx
+++ b/src/pages/profilePage/ProfileHeader/MyProfileBtns.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import Button from '../../../components/common/Button/Button';
+
+const MyProfileBtns = () => {
+  return (
+    <MyProfileBtnsStyle>
+      <li>
+        <Button
+          size='M'
+          backgroundColor={'var(--main-bg-color)'}
+          borderColor={'var(--border-color)'}
+          textColor={'var(--sub-text-color)'}
+        >
+          프로필 수정
+        </Button>
+      </li>
+      <li>
+        <Button
+          size='M'
+          backgroundColor={'var(--main-bg-color)'}
+          borderColor={'var(--border-color)'}
+          textColor={'var(--sub-text-color)'}
+        >
+          상품 등록
+        </Button>
+      </li>
+    </MyProfileBtnsStyle>
+  );
+};
+
+export default MyProfileBtns;
+
+const MyProfileBtnsStyle = styled.ul`
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin: 2.4em 0 3.4em 0;
+`;

--- a/src/pages/profilePage/ProfileHeader/ProfileHeader.jsx
+++ b/src/pages/profilePage/ProfileHeader/ProfileHeader.jsx
@@ -1,15 +1,17 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
+import UserProfileBtns from './UserProfileBtns';
+import MyProfileBtns from './MyProfileBtns';
 import ProfileImage from '../../../components/common/ProfileImage/ProfileImage';
 import { PROFILE1_IMAGE } from '../../../styles/CommonImages';
-import { CHAT_ICON, SHARE_ICON } from '../../../styles/CommonIcons';
-import Button from '../../../components/common/Button/Button';
 
-const ProfileHeader = () => {
+const ProfileHeader = ({ profileState, followState }) => {
+  const [isMyProfile, setIsMyProfile] = useState(false);
+
   return (
     <ProfileWrapper>
-      <h2 className="sr-only">프로필 정보</h2>
+      <h2 className='sr-only'>프로필 정보</h2>
       <Followers>
         <strong>2950</strong>
         <span>followers</span>
@@ -22,11 +24,8 @@ const ProfileHeader = () => {
         <strong>128</strong>
         <span>followings</span>
       </Followings>
-      <ProfileBtns>
-        <ProfileBtn />
-        <Button size='M'>팔로우</Button>
-        <ProfileBtn isShare={true} />
-      </ProfileBtns>
+      {/* isMyProfile에 따라 MyProfileBtns 과 UserProfileBtns 나뉘게 / */}
+      {isMyProfile == true ? <MyProfileBtns /> : <UserProfileBtns isFollowing={true} />}
     </ProfileWrapper>
   );
 };
@@ -100,23 +99,4 @@ const Followings = styled.div`
     color: var(--sub-text-color);
     font-size: 1em;
   }
-`;
-
-const ProfileBtns = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 1em;
-  margin-top: 2.4em;
-  margin-bottom: 2.6em;
-`;
-
-const ProfileBtn = styled.button`
-  background: ${(props) =>
-    props.isShare ? `url(${SHARE_ICON}) no-repeat center / 15px` : `url(${CHAT_ICON}) no-repeat center / 15px`};
-  width: 34px;
-  height: 34px;
-  color: var(--sub-text-color);
-  border: 1px solid var(--border-color);
-  border-radius: 50%;
 `;

--- a/src/pages/profilePage/ProfileHeader/UserProfileBtns.jsx
+++ b/src/pages/profilePage/ProfileHeader/UserProfileBtns.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useState } from 'react';
+import styled from 'styled-components';
+import Button from '../../../components/common/Button/Button';
+import { CHAT_ICON, SHARE_ICON } from '../../../styles/CommonIcons';
+
+const UserProfileBtns = ({ followState }) => {
+  const [isFollowing, setIsFollowing] = useState(followState);
+
+  function handleFollow() {
+    setIsFollowing(!isFollowing);
+  }
+  return (
+    <UserProfileBtnsStyle>
+      {/* followState 에 따라 팔로우/언팔로우 버튼으로 나뉩니다*/}
+      <ProfileBtn />
+      <Button
+        size='M'
+        onClickHandler={handleFollow}
+        backgroundColor={isFollowing ? 'var(--login-bg-color)' : 'var(--main-bg-color)'}
+        borderColor={isFollowing ? 'transparent' : 'var(--border-color)'}
+        textColor={isFollowing ? 'var(--main-bg-color)' : 'var(--sub-text-color)'}
+      >
+        {isFollowing ? '팔로우' : '언팔로우'}
+      </Button>
+      <ProfileBtn isShare={true} />
+    </UserProfileBtnsStyle>
+  );
+};
+
+export default UserProfileBtns;
+
+const UserProfileBtnsStyle = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1em;
+  margin-top: 2.4em;
+  margin-bottom: 2.6em;
+`;
+
+const ProfileBtn = styled.button`
+  background: ${(props) =>
+    props.isShare ? `url(${SHARE_ICON}) no-repeat center / 15px` : `url(${CHAT_ICON}) no-repeat center / 15px`};
+  width: 34px;
+  height: 34px;
+  color: var(--sub-text-color);
+  border: 1px solid var(--border-color);
+  border-radius: 50%;
+`;

--- a/src/pages/profilePage/ProfilePage.jsx
+++ b/src/pages/profilePage/ProfilePage.jsx
@@ -15,9 +15,9 @@ const ProfilePage = () => {
       <ContentsLayout padding='2rem 0 0 0'>
         <ProfileHeader></ProfileHeader>
         <SectionBorder />
-        <ProfileProduct></ProfileProduct>
+        <ProfileProduct />
         <SectionBorder />
-        <ProfilePost></ProfilePost>
+        <ProfilePost />
       </ContentsLayout>
       <TabMenu />
     </>


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
* my profile 과 your profile 구분 => isMyProfile  useState 추가해서 myprofile 과 userProfile 로 나뉘게끔 작업했습니다.
    `const [isMyProfile,setIstMyProfile] = useState('')`
* userProfile 에서 followstate에 따라  팔로우했는지/안했는지 => 팔로우/언팔로우 버튼 나뉘게끔 작업했습니다.
    `const [isFollowing, setIsFollowing] = useState(followState);`


## 관련 이슈 번호
close : #132
