### PR TITLE
design: 판매 중인 상품에 모달 연결 (#136)

### DIFF
--- a/src/components/carousel/MultiItemCarousel/MultiItemCarousel.jsx
+++ b/src/components/carousel/MultiItemCarousel/MultiItemCarousel.jsx
@@ -3,8 +3,23 @@ import Product from '../../common/Product/Product';
 import 'swiper/css';
 import { Pagination } from 'swiper';
 import './multiItemCarousel.css';
+import { useState } from 'react';
+import ProductModal from '../../common/modal/ProductModal/ProductModal';
+import { useNavigate } from 'react-router-dom';
 
 export default function App() {
+  const [isOpenModal, setIsOpenModal] = useState(false);
+  const [isMyProduct, setIsMyProduct] = useState(true); // 모달 테스트용으로 넣어둔 코드입니다. true인 경우에만 모달 출력, false인 경우(다른 사람의 상품인 경우) 상품 링크로 바로 이동되어야 합니다.
+  const navigate = useNavigate();
+
+  const closeModal = () => {
+    setIsOpenModal(false);
+  };
+
+  const moveProductUrl = (url) => {
+    window.open(url);
+  };
+
   return (
     <>
       <Swiper
@@ -16,24 +31,55 @@ export default function App() {
         className='mySwiper'
       >
         <SwiperSlide>
-          <Product productImg='https://picsum.photos/250/250' productName='감귤인형' productPrice='30000' />
+          <Product
+            productImg='https://picsum.photos/250/250'
+            productName='감귤인형'
+            productPrice='30000'
+            onClick={() => (isMyProduct ? setIsOpenModal(true) : moveProductUrl('https://www.naver.com'))}
+          />
         </SwiperSlide>
         <SwiperSlide>
-          <Product productImg='https://picsum.photos/250/250' productName='감귤인형' productPrice='30000' />
+          <Product
+            productImg='https://picsum.photos/250/250'
+            productName='감귤인형'
+            productPrice='30000'
+            onClick={() => (isMyProduct ? setIsOpenModal(true) : moveProductUrl('https://www.naver.com'))}
+          />
         </SwiperSlide>
         <SwiperSlide>
-          <Product productImg='https://picsum.photos/250/250' productName='감귤인형' productPrice='30000' />
+          <Product
+            productImg='https://picsum.photos/250/250'
+            productName='감귤인형'
+            productPrice='30000'
+            onClick={() => (isMyProduct ? setIsOpenModal(true) : moveProductUrl('https://www.naver.com'))}
+          />
         </SwiperSlide>
         <SwiperSlide>
-          <Product productImg='https://picsum.photos/250/250' productName='감귤인형' productPrice='30000' />
+          <Product
+            productImg='https://picsum.photos/250/250'
+            productName='감귤인형'
+            productPrice='30000'
+            onClick={() => (isMyProduct ? setIsOpenModal(true) : moveProductUrl('https://www.naver.com'))}
+          />
         </SwiperSlide>
         <SwiperSlide>
-          <Product productImg='https://picsum.photos/250/250' productName='감귤인형' productPrice='30000' />
+          <Product
+            productImg='https://picsum.photos/250/250'
+            productName='감귤인형'
+            productPrice='30000'
+            onClick={() => (isMyProduct ? setIsOpenModal(true) : moveProductUrl('https://www.naver.com'))}
+          />
         </SwiperSlide>
         <SwiperSlide>
-          <Product productImg='https://picsum.photos/250/250' productName='감귤인형' productPrice='30000' />
+          <Product
+            productImg='https://picsum.photos/250/250'
+            productName='감귤인형'
+            productPrice='30000'
+            onClick={() => (isMyProduct ? setIsOpenModal(true) : moveProductUrl('https://www.naver.com'))}
+          />
         </SwiperSlide>
       </Swiper>
+      {isOpenModal ? <ProductModal closeModal={closeModal} /> : <></>}
     </>
   );
 }

--- a/src/components/common/Product/Product.jsx
+++ b/src/components/common/Product/Product.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const Product = ({ productImg, productName, productPrice }) => {
+const Product = ({ onClick, productImg, productName, productPrice }) => {
   return (
     <>
-      <WrapperDiv>
+      <WrapperDiv onClick={onClick}>
         <ProductImg src={productImg} alt={`${productName} 상품 이미지`} />
         <ProductName>{productName}</ProductName>
         <ProductPrice>{productPrice}</ProductPrice>


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 판매 중인 상품과 ProductModal 연결


## 기대 결과
- Product가 onClick을 props로 전달 받음
- 내가 판매 중인 상품 클릭 시 ProductModal 출력
- 다른 사람이 판매 중인 상품 클릭 시 상품 url으로 이동


## 리뷰어에게 전달 사항
- 현재는 상품 리스트가 MultiItemCarousel 안에 있는데, 상품과 캐러셀의 독립성을 유지하기 위해 기능 개발시 분리할 필요가 있어 보입니다!
- 아래 부분은 테스트를 위해 넣어놓은 사항으로 기능 개발시 필요가 없다면 삭제하셔도 됩니다.
https://github.com/daengnyang-market/daengnyang-market-client/blob/0e85461af069211eb7c4617d3ff88eb8bf7ecb72/src/components/carousel/MultiItemCarousel/MultiItemCarousel.jsx#L12

## 스크린샷
![스크린샷 2022-12-16 오후 9 14 36](https://user-images.githubusercontent.com/105365737/208096034-731bb230-ae0e-4f1d-b69b-f4f70a8d5ebd.png)
- 내 판매 상품인 경우 모달 출력

![스크린샷 2022-12-16 오후 9 14 55](https://user-images.githubusercontent.com/105365737/208096055-83ee092c-6c22-4b01-b7ac-eb57b85cdd6a.png)
- 다른 사람의 판매 상품인 경우 상품 url으로 이동(새 탭으로 이동)
- 현재는 테스트용으로 네이버 주소를 넣어놓았음

## 관련 이슈 번호
close : #136 
