### PR TITLE
design: 선택한 페이지에 따라 TabMenu 스타일 변경 (#146)

### DIFF
--- a/src/components/common/TabMenu/TabMenu.jsx
+++ b/src/components/common/TabMenu/TabMenu.jsx
@@ -7,35 +7,32 @@ import {
   CHAT_ICON,
   CHAT_FILL_ICON,
   EDIT_ICON,
+  EDIT_FILL_ICON,
   COMMUNITY_ICON,
   COMMUNITY_FILL_ICON,
   USER_ICON,
   USER_FILL_ICON,
 } from '../../../styles/CommonIcons';
 
-const TabMenu = () => {
+const TabMenu = ({ selectMenuId = 0 }) => {
+  const menuList = [
+    { id: 0, title: '홈', icon: HOME_ICON, fillIcon: HOME_FILL_ICON },
+    { id: 1, title: '채팅', icon: CHAT_ICON, fillIcon: CHAT_FILL_ICON },
+    { id: 2, title: '게시물 작성', icon: EDIT_ICON, fillIcon: EDIT_FILL_ICON },
+    { id: 3, title: '집사생활', icon: COMMUNITY_ICON, fillIcon: COMMUNITY_FILL_ICON },
+    { id: 4, title: '프로필', icon: USER_ICON, fillIcon: USER_FILL_ICON },
+  ];
+
   return (
     <TabMenuDiv>
-      <TabMenuIconBtn>
-        <img src={HOME_ICON} alt='' />
-        <span>홈</span>
-      </TabMenuIconBtn>
-      <TabMenuIconBtn>
-        <img src={CHAT_ICON} alt='' />
-        <span>채팅</span>
-      </TabMenuIconBtn>
-      <TabMenuIconBtn>
-        <img src={EDIT_ICON} alt='' />
-        <span>게시물 작성</span>
-      </TabMenuIconBtn>
-      <TabMenuIconBtn>
-        <img src={COMMUNITY_ICON} alt='' />
-        <span>집사생활</span>
-      </TabMenuIconBtn>
-      <TabMenuIconBtn>
-        <img src={USER_ICON} alt='' />
-        <span>프로필</span>
-      </TabMenuIconBtn>
+      {menuList.map(({ id, title, icon, fillIcon }) => (
+        <TabMenuIconBtn key={id}>
+          <img src={id === selectMenuId ? fillIcon : icon} alt='' />
+          <TabMenuTitle id={id} selectMenuId={selectMenuId}>
+            {title}
+          </TabMenuTitle>
+        </TabMenuIconBtn>
+      ))}
     </TabMenuDiv>
   );
 };
@@ -64,9 +61,10 @@ const TabMenuIconBtn = styled.button`
     width: 24px;
     height: 24px;
   }
-  & span {
-    margin-top: 0.6em;
-    font-size: 1em;
-    color: var(--sub-text-color);
-  }
+`;
+
+const TabMenuTitle = styled.span`
+  margin-top: 0.6em;
+  font-size: 1em;
+  color: ${(props) => (props.id === props.selectMenuId ? 'var(--login-bg-color)' : 'var(--sub-text-color)')};
 `;

--- a/src/components/common/TabMenu/TabMenu.jsx
+++ b/src/components/common/TabMenu/TabMenu.jsx
@@ -14,7 +14,7 @@ import {
   USER_FILL_ICON,
 } from '../../../styles/CommonIcons';
 
-const TabMenu = ({ selectMenuId = 0 }) => {
+const TabMenu = ({ currentMenuId = 0 }) => {
   const menuList = [
     { id: 0, title: '홈', icon: HOME_ICON, fillIcon: HOME_FILL_ICON },
     { id: 1, title: '채팅', icon: CHAT_ICON, fillIcon: CHAT_FILL_ICON },
@@ -27,8 +27,8 @@ const TabMenu = ({ selectMenuId = 0 }) => {
     <TabMenuDiv>
       {menuList.map(({ id, title, icon, fillIcon }) => (
         <TabMenuIconBtn key={id}>
-          <img src={id === selectMenuId ? fillIcon : icon} alt='' />
-          <TabMenuTitle id={id} selectMenuId={selectMenuId}>
+          <img src={id === currentMenuId ? fillIcon : icon} alt='' />
+          <TabMenuTitle id={id} currentMenuId={currentMenuId}>
             {title}
           </TabMenuTitle>
         </TabMenuIconBtn>
@@ -66,5 +66,5 @@ const TabMenuIconBtn = styled.button`
 const TabMenuTitle = styled.span`
   margin-top: 0.6em;
   font-size: 1em;
-  color: ${(props) => (props.id === props.selectMenuId ? 'var(--login-bg-color)' : 'var(--sub-text-color)')};
+  color: ${(props) => (props.id === props.currentMenuId ? 'var(--login-bg-color)' : 'var(--sub-text-color)')};
 `;


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 디자인 시안과 동일하게 구현하기 위해 추가했습니다.


## 기대 결과
- 선택한 페이지에 따라 TabMenu 스타일이 변경됩니다.


## 리뷰어에게 전달 사항
- TabMenu에 props로 currentMenuId를 전달해주세요.
- id 종류
  - 0 : 홈(생략시 기본값)
  - 1 : 채팅
  - 2 : 게시물 작성
  - 3 : 집사생활
  - 4 :  프로필
- 예) 채팅 페이지일 때
  - `<TabMenu currentMenuId={1} />`

## 스크린샷
![스크린샷 2022-12-16 오후 9 51 49](https://user-images.githubusercontent.com/105365737/208102964-ca54e685-d6af-461f-94da-6a6e26b14121.png)
- 값을 생략했을때 (홈)

![스크린샷 2022-12-16 오후 9 53 45](https://user-images.githubusercontent.com/105365737/208103031-35329e88-2f99-4d0c-83f6-65be72de410b.png)
- currentMenuId={3}을 전달했을때 (집사생활)

## 관련 이슈 번호
close : #146 
