### PR TITLE
chore: ESLint에 switch-case문 들여쓰기 규칙 추가 (#156)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": ["react-app", "react-app/jest", "prettier"],
   "rules": {
-    "indent": ["error", 2], // 들여쓰기 2칸만 허용
+    "indent": ["error", 2, { "SwitchCase": 1 }], // 들여쓰기 2칸만 허용
     "no-var": "error", // // var 키워드 사용 금지
     "require-await": "error", // async 함수 내부에 await 키워드가 없으면 오류 발생
     "eqeqeq": "warn", // ==, != 대신에 ===, !== 사용


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [x] 기타


## 왜 코드를 추가/변경하였나요?
- switch-case문 사용시 ESLint 규칙에 어긋나 에러 발생
- 에러를 해결하기 위해 switch-case문 들여쓰기 규칙 추가


## 기대 결과
- switch-case 사용시 ESLint 에러가 발생하지 않아야 합니다.


## 리뷰어에게 전달 사항
- `SwitchCase: 1'의 의미
  - `SwitchCase가 1로 설정된 상태에서는 2칸으로 case 절을 ​​들여씁니다.`
  - 출처: [Cannot fix eslint rule on indenting case statements in switch statement](https://stackoverflow.com/questions/53055300/cannot-fix-eslint-rule-on-indenting-case-statements-in-switch-statement)

- 추가 사항
  - ESLint가 적용된 상태에서 switch-case문을 사용할때는 default 구문이 꼭 있어야 합니다. default 구문을 작성하지 않으면 오류는 나지 않지만 경고가 계속 출력됩니다.


## 관련 이슈 번호
close : #156 
