### PR TITLE
feat: TabMenu에 페이지 연결 (#158)

### DIFF
--- a/src/components/common/TabMenu/TabMenu.jsx
+++ b/src/components/common/TabMenu/TabMenu.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import {
@@ -15,6 +16,8 @@ import {
 } from '../../../styles/CommonIcons';
 
 const TabMenu = ({ currentMenuId = 0 }) => {
+  const navigate = useNavigate();
+
   const menuList = [
     { id: 0, title: '홈', icon: HOME_ICON, fillIcon: HOME_FILL_ICON },
     { id: 1, title: '채팅', icon: CHAT_ICON, fillIcon: CHAT_FILL_ICON },
@@ -23,10 +26,36 @@ const TabMenu = ({ currentMenuId = 0 }) => {
     { id: 4, title: '프로필', icon: USER_ICON, fillIcon: USER_FILL_ICON },
   ];
 
+  const moveSelectMenu = (id) => {
+    switch (id) {
+      case 0:
+        navigate('/home');
+        break;
+
+      case 1:
+        navigate('/chat');
+        break;
+
+      case 2:
+        navigate('/post/upload');
+        break;
+
+      case 3:
+        navigate('/community');
+        break;
+
+      case 4:
+        navigate('/profile');
+        break;
+
+      default:
+    }
+  };
+
   return (
     <TabMenuDiv>
       {menuList.map(({ id, title, icon, fillIcon }) => (
-        <TabMenuIconBtn key={id}>
+        <TabMenuIconBtn key={id} onClick={() => moveSelectMenu(id)}>
           <img src={id === currentMenuId ? fillIcon : icon} alt='' />
           <TabMenuTitle id={id} currentMenuId={currentMenuId}>
             {title}

--- a/src/pages/FollowListPage/FollowListPage.jsx
+++ b/src/pages/FollowListPage/FollowListPage.jsx
@@ -20,7 +20,7 @@ const FollowListPage = () => {
           <Follow />
         </FollowList>
       </ContentsLayout>
-      <TabMenu />
+      <TabMenu currentMenuId={4} />
     </>
   );
 };

--- a/src/pages/communityPage/CommunityLayout.jsx
+++ b/src/pages/communityPage/CommunityLayout.jsx
@@ -20,7 +20,7 @@ const CommunityLayout = ({ children, navType = 'mainNav', selectMenuId }) => {
         <CommunityMenu selectMenuId={selectMenuId} />
         {children}
       </ContentsLayout>
-      <TabMenu />
+      <TabMenu currentMenuId={3} />
     </>
   );
 };

--- a/src/pages/profilePage/ProfilePage.jsx
+++ b/src/pages/profilePage/ProfilePage.jsx
@@ -19,7 +19,7 @@ const ProfilePage = () => {
         <SectionBorder />
         <ProfilePost />
       </ContentsLayout>
-      <TabMenu />
+      <TabMenu currentMenuId={4} />
     </>
   );
 };

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -26,7 +26,7 @@ const Router = () => {
       {/* 회원만 진입 가능 페이지 */}
       <Route path='/home' element={<FeedPage />} />
       <Route path='/search' element={<SearchPage />} />
-      <Route path='/profile/' element={<ProfilePage />} />
+      <Route path='/profile' element={<ProfilePage />} />
       <Route path='/profile/:accountname' element={<ProfilePage />} />
       <Route path='/profile/edit' element={<ProfileModificationPage />} />
       <Route path='/follow/:accountname/:type' element={<FollowListPage />} />
@@ -38,6 +38,10 @@ const Router = () => {
       <Route path='/community/weather' element={<CommunityWeatherPage />} />
       <Route path='/community/hospital' element={<CommunityHospitaMainlPage />} />
       <Route path='/community/hospital/:hospitalid' element={<CommunityHospitalDetailPage />} />
+      <Route path='/chat' element={<></>} />
+      <Route path='/chat/:accountname' element={<></>} />
+      <Route path='*' element={<></>} />
+      <Route path='/notfound' element={<></>} />
     </Routes>
   );
 };


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 페이지들을 연결하기 위해서 추가했습니다.


## 기대 결과
- 하단 TabMenu 클릭시 페이지와 TabMenu 스타일이 변경됨


## 리뷰어에게 전달 사항
- **주의! '/'는 현재 Splash 페이지로 연결되고 있으므로 '/home'으로 진입해야 확인이 가능합니다.**
- 채팅방 목록 페이지는 아직 작업중인 관계로 연결되지 않았습니다.
- 채팅방 목록 페이지 작업자분께서는 작업 후 아래의 과정을 통해 TabMenu와 연결해주세요!
  1. routes/Router.jsx에 컴포넌트 추가
     - 41번째 라인 `<Route path='/chat' element={<></>} />` 여기 element안에 다른 라우터들과 똑같이 컴포넌트 넣어주시면 됩니다!
  2. 채팅방 목록 페이지 내 TabMenu 컴포넌트에 currentMenuId={1} 전달
     - 예: `<TabMenu currentMenuId={1} />`


## 스크린샷
![Dec-17-2022 10-37-36](https://user-images.githubusercontent.com/105365737/208217157-a0e4ead5-5992-409a-9e0d-82ce4e25c191.gif)



## 관련 이슈 번호
close : #158 
