### PR TITLE
feat: ProfilePage에 모달 연결 (#135)

### DIFF
--- a/src/components/common/TopNavBar/TopBasicNav.jsx
+++ b/src/components/common/TopNavBar/TopBasicNav.jsx
@@ -1,19 +1,40 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { TopNavBar, LeftArrow, MoreBtn } from './Styled';
 
 import { LEFT_ARROW_ICON, MORE_ICON } from '../../../styles/CommonIcons';
+import ProfileModal from '../modal/ProfileModal/ProfileModal';
+import ChatRoomModal from '../modal/ChatRoomModal/ChatRoomModal';
 
-const TopBasicNav = () => {
+const TopBasicNav = ({ pageType }) => {
+  const [isOpenModal, setIsOpenModal] = useState(false);
+
+  const closeModal = () => {
+    setIsOpenModal(false);
+  };
+
   return (
-    <TopNavBar>
-      <Link to='/'>
-        <LeftArrow src={LEFT_ARROW_ICON} alt='뒤로가기 버튼' />
-      </Link>
-      <MoreBtn>
-        <img src={MORE_ICON} alt='더보기 버튼' />
-      </MoreBtn>
-    </TopNavBar>
+    <>
+      <TopNavBar>
+        <Link to='/'>
+          <LeftArrow src={LEFT_ARROW_ICON} alt='뒤로가기 버튼' />
+        </Link>
+        <MoreBtn onClick={() => setIsOpenModal(true)}>
+          <img src={MORE_ICON} alt='더보기 버튼' />
+        </MoreBtn>
+      </TopNavBar>
+      {isOpenModal ? (
+        pageType === 'profile' ? (
+          <ProfileModal closeModal={closeModal} />
+        ) : pageType === 'chatRoom' ? (
+          <ChatRoomModal closeModal={closeModal} />
+        ) : (
+          <></>
+        )
+      ) : (
+        <></>
+      )}
+    </>
   );
 };
 

--- a/src/components/common/modal/ProfileModal/ProfileModal.jsx
+++ b/src/components/common/modal/ProfileModal/ProfileModal.jsx
@@ -21,7 +21,7 @@ const ProfileModal = ({ closeModal }) => {
       <ModalLayout closeModal={closeModal} isOpenAlert={isOpenAlert}>
         <MenuList>
           <MenuItem>
-            <Link to='#'>설정 및 개인정보</Link>
+            <Link to='/profile/edit'>설정 및 개인정보</Link>
           </MenuItem>
           <MenuItem>
             <button type='button' onClick={() => setIsOpenAlert(true)}>

--- a/src/pages/profilePage/ProfilePage.jsx
+++ b/src/pages/profilePage/ProfilePage.jsx
@@ -11,7 +11,7 @@ import ProfilePost from './ProfilePost/ProfilePost';
 const ProfilePage = () => {
   return (
     <>
-      <TopBasicNav />
+      <TopBasicNav pageType='profile' />
       <ContentsLayout padding='2rem 0 0 0'>
         <ProfileHeader></ProfileHeader>
         <SectionBorder />


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- ProfilePage 내 헤더 더보기 버튼 클릭시 모달창이 뜨도록 추가했습니다.


## 기대 결과
- ProfilePage 내 헤더 더보기 버튼 클릭시 모달창이 뜹니다.
- 설정 및 개인정보 링크를 클릭하면 프로필 수정 페이지로 이동됩니다.


## 스크린샷
![Dec-17-2022 11-44-47](https://user-images.githubusercontent.com/105365737/208219987-16cbf859-cb27-4eeb-80f5-1fa56c835582.gif)


## 관련 이슈 번호
close : #135 
