### PR TITLE
feat: TopNavBar 뒤로가기 및 search 페이지로 이동 기능 추가 (#163)

### DIFF
--- a/src/components/common/TopNavBar/TopBasicNav.jsx
+++ b/src/components/common/TopNavBar/TopBasicNav.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { TopNavBar, LeftArrow, MoreBtn } from './Styled';
 
 import { LEFT_ARROW_ICON, MORE_ICON } from '../../../styles/CommonIcons';
 
 const TopBasicNav = () => {
+  const navigate = useNavigate();
+
   return (
     <TopNavBar>
-      <Link to='/'>
+      <button onClick={() => navigate(-1)}>
         <LeftArrow src={LEFT_ARROW_ICON} alt='뒤로가기 버튼' />
-      </Link>
+      </button>
       <MoreBtn>
         <img src={MORE_ICON} alt='더보기 버튼' />
       </MoreBtn>

--- a/src/components/common/TopNavBar/TopMainNav.jsx
+++ b/src/components/common/TopNavBar/TopMainNav.jsx
@@ -3,13 +3,16 @@ import styled from 'styled-components';
 
 import { TopNavBar, SearchBtn } from './Styled';
 import { SEARCH_ICON } from '../../../styles/CommonIcons';
+import { useNavigate } from 'react-router-dom';
 
 const TopMainNav = ({ title, viewSearchBtn = true }) => {
+  const navigate = useNavigate();
+
   return (
     <TopNavBar>
       <TopNavH1>{title}</TopNavH1>
       {viewSearchBtn ? (
-        <SearchBtn>
+        <SearchBtn onClick={() => navigate('/search')}>
           <img src={SEARCH_ICON} alt='검색하기 버튼' />
         </SearchBtn>
       ) : (

--- a/src/components/common/TopNavBar/TopSearchNav.jsx
+++ b/src/components/common/TopNavBar/TopSearchNav.jsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { TopNavBar, LeftArrow } from './Styled';
 import { LEFT_ARROW_ICON } from '../../../styles/CommonIcons';
 
 const TopSearchNav = () => {
+  const navigate = useNavigate();
+
   return (
     <TopNavBar>
-      <Link to='/'>
+      <button onClick={() => navigate(-1)}>
         <LeftArrow src={LEFT_ARROW_ICON} alt='뒤로가기 버튼' />
-      </Link>
+      </button>
       <SearchInput placeholder='계정 검색' />
     </TopNavBar>
   );

--- a/src/components/common/TopNavBar/TopTitleNav.jsx
+++ b/src/components/common/TopNavBar/TopTitleNav.jsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { TopNavBar, LeftArrow, MoreBtn } from './Styled';
 import { LEFT_ARROW_ICON, MORE_ICON } from '../../../styles/CommonIcons';
 
 const TopTitleNav = ({ title, viewMoreBtn = true }) => {
+  const navigate = useNavigate();
+
   return (
     <TopNavBar>
-      <Link to='/'>
+      <button onClick={() => navigate(-1)}>
         <LeftArrow src={LEFT_ARROW_ICON} alt='뒤로가기 버튼' />
-      </Link>
+      </button>
       <TopNavH2>{title}</TopNavH2>
       {viewMoreBtn ? (
         <MoreBtn>

--- a/src/components/common/TopNavBar/TopUploadNav.jsx
+++ b/src/components/common/TopNavBar/TopUploadNav.jsx
@@ -1,16 +1,18 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { TopNavBar, LeftArrow } from './Styled';
 import { LEFT_ARROW_ICON } from '../../../styles/CommonIcons';
 import Button from '../Button/Button';
 
 const TopUploadNav = () => {
+  const navigate = useNavigate();
+
   return (
     <TopNavBar>
-      <Link to='/'>
+      <button onClick={() => navigate(-1)}>
         <LeftArrow src={LEFT_ARROW_ICON} alt='뒤로가기버튼' />
-      </Link>
+      </button>
       <Button size='MS'>저장</Button>
     </TopNavBar>
   );


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- TopNav에 이동 기능을 추가하기 위해 수정했습니다.


## 기대 결과
- TopBasicNav, TopSearchNav, TopUploadNav, TopTitleNav에서 뒤로가기 버튼을 누르면 이전 페이지로 이동됩니다.
- TopMainNav에서 검색 버튼을 누르면 search 페이지로 이동됩니다.



## 관련 이슈 번호
close : #163 
