### PR TITLE
feat: 채팅방에 모달 연결 (#140)

### DIFF
--- a/src/components/common/TopNavBar/TopBasicNav.jsx
+++ b/src/components/common/TopNavBar/TopBasicNav.jsx
@@ -4,9 +4,8 @@ import { TopNavBar, LeftArrow, MoreBtn } from './Styled';
 
 import { LEFT_ARROW_ICON, MORE_ICON } from '../../../styles/CommonIcons';
 import ProfileModal from '../modal/ProfileModal/ProfileModal';
-import ChatRoomModal from '../modal/ChatRoomModal/ChatRoomModal';
 
-const TopBasicNav = ({ pageType }) => {
+const TopBasicNav = () => {
   const navigate = useNavigate();
 
   const [isOpenModal, setIsOpenModal] = useState(false);
@@ -25,17 +24,7 @@ const TopBasicNav = ({ pageType }) => {
           <img src={MORE_ICON} alt='더보기 버튼' />
         </MoreBtn>
       </TopNavBar>
-      {isOpenModal ? (
-        pageType === 'profile' ? (
-          <ProfileModal closeModal={closeModal} />
-        ) : pageType === 'chatRoom' ? (
-          <ChatRoomModal closeModal={closeModal} />
-        ) : (
-          <></>
-        )
-      ) : (
-        <></>
-      )}
+      {isOpenModal ? <ProfileModal closeModal={closeModal} /> : <></>}
     </>
   );
 };

--- a/src/components/common/TopNavBar/TopTitleNav.jsx
+++ b/src/components/common/TopNavBar/TopTitleNav.jsx
@@ -1,27 +1,37 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 
 import { TopNavBar, LeftArrow, MoreBtn } from './Styled';
 import { LEFT_ARROW_ICON, MORE_ICON } from '../../../styles/CommonIcons';
+import ChatRoomModal from '../modal/ChatRoomModal/ChatRoomModal';
 
 const TopTitleNav = ({ title, viewMoreBtn = true }) => {
   const navigate = useNavigate();
 
+  const [isOpenModal, setIsOpenModal] = useState(false);
+
+  const closeModal = () => {
+    setIsOpenModal(false);
+  };
+
   return (
-    <TopNavBar>
-      <button onClick={() => navigate(-1)}>
-        <LeftArrow src={LEFT_ARROW_ICON} alt='뒤로가기 버튼' />
-      </button>
-      <TopNavH2>{title}</TopNavH2>
-      {viewMoreBtn ? (
-        <MoreBtn>
-          <img src={MORE_ICON} alt='더보기 버튼' />
-        </MoreBtn>
-      ) : (
-        <></>
-      )}
-    </TopNavBar>
+    <>
+      <TopNavBar>
+        <button onClick={() => navigate(-1)}>
+          <LeftArrow src={LEFT_ARROW_ICON} alt='뒤로가기 버튼' />
+        </button>
+        <TopNavH2>{title}</TopNavH2>
+        {viewMoreBtn ? (
+          <MoreBtn onClick={() => setIsOpenModal(true)}>
+            <img src={MORE_ICON} alt='더보기 버튼' />
+          </MoreBtn>
+        ) : (
+          <></>
+        )}
+      </TopNavBar>
+      {isOpenModal ? <ChatRoomModal closeModal={closeModal} /> : <></>}
+    </>
   );
 };
 

--- a/src/pages/profilePage/ProfilePage.jsx
+++ b/src/pages/profilePage/ProfilePage.jsx
@@ -11,7 +11,7 @@ import ProfilePost from './ProfilePost/ProfilePost';
 const ProfilePage = () => {
   return (
     <>
-      <TopBasicNav pageType='profile' />
+      <TopBasicNav />
       <ContentsLayout padding='2rem 0 0 0'>
         <ProfileHeader profileState={true} followState={false} />
         <SectionBorder />

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
+import ChatRoomPage from '../pages/ChatRoomPage/ChatRoomPage';
 import CommunityHospitalDetailPage from '../pages/communityPage/communityHospitalPage/CommunityHospitalDetailPage/CommunityHospitalDetailPage';
 import CommunityHospitaMainlPage from '../pages/communityPage/communityHospitalPage/CommunityHospitalMainPage/CommunityHospitaMainlPage';
 import CommunityMainPage from '../pages/communityPage/CommunityMainPage/CommunityMainPage';
@@ -39,7 +40,7 @@ const Router = () => {
       <Route path='/community/hospital' element={<CommunityHospitaMainlPage />} />
       <Route path='/community/hospital/:hospitalid' element={<CommunityHospitalDetailPage />} />
       <Route path='/chat' element={<></>} />
-      <Route path='/chat/:accountname' element={<></>} />
+      <Route path='/chat/:accountname' element={<ChatRoomPage />} />
       <Route path='*' element={<></>} />
       <Route path='/notfound' element={<></>} />
     </Routes>


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [x] 기타


## 왜 코드를 추가/변경하였나요?
- 채팅방 페이지에서 더보기 버튼 클릭 시 ChatRoomModal을 띄우기 위해 변경


## 기대 결과
- 채팅방 페이지에서 더보기 버튼 클릭 시 채팅방 나가기 모달 출력


## 리뷰어에게 전달 사항
- 수정 사항
  - 라우터에 ChatRoomPage 추가
  - TopBasicNav는 ProfileModal으로만 연결되면 됨. 따라서 pageType 옵션 제거
  - TopTitleNav에 더보기 버튼 클릭 시 ChatRoomModal 출력


## 스크린샷
![Dec-17-2022 12-35-38](https://user-images.githubusercontent.com/105365737/208221880-9dd143e5-0045-4453-bb1f-accc6a32385c.gif)


## 관련 이슈 번호
close : #140 
