### PR TITLE
feat: SplashPage에서 LoginMainPage로 자동 이동 기능 추가 (#170)

### DIFF
--- a/src/components/common/Animation/Animation.jsx
+++ b/src/components/common/Animation/Animation.jsx
@@ -11,7 +11,7 @@ export const fadeIn = keyframes`
 `;
 
 export const fadeOut = keyframes`
-  75% {
+  65% {
     opacity: 1
   }
   

--- a/src/components/common/Animation/Animation.jsx
+++ b/src/components/common/Animation/Animation.jsx
@@ -9,3 +9,13 @@ export const fadeIn = keyframes`
     opacity: 1
   }
 `;
+
+export const fadeOut = keyframes`
+  80% {
+    opacity: 1
+  }
+  
+  100% {
+    opacity: 0
+  }
+`;

--- a/src/components/common/Animation/Animation.jsx
+++ b/src/components/common/Animation/Animation.jsx
@@ -11,7 +11,7 @@ export const fadeIn = keyframes`
 `;
 
 export const fadeOut = keyframes`
-  80% {
+  75% {
     opacity: 1
   }
   

--- a/src/pages/LoginMainPage/LoginMainPage.jsx
+++ b/src/pages/LoginMainPage/LoginMainPage.jsx
@@ -2,38 +2,41 @@ import styled from 'styled-components';
 import { LOGO_WHITE_IMAGE } from '../../styles/CommonImages';
 import { KAKAO_ICON, GOOGLE_ICON, FACEBOOK_ICON } from '../../styles/CommonIcons';
 import { fadeIn } from '../../components/common/Animation/Animation';
+import { Link } from 'react-router-dom';
 
 const LoginMainPage = () => {
   return (
-    <Main>
-      <LogoHeadingWrapper>
-        <LogoHeadingOne>
-          <LogoImg src={LOGO_WHITE_IMAGE} alt='가져도댕냥 로고' />
-        </LogoHeadingOne>
-      </LogoHeadingWrapper>
-      <LoginSection>
-        <KakaoButton>
-          <CommonStyleImg src={KAKAO_ICON} alt='' />
-          카카오 계정으로 로그인
-        </KakaoButton>
-        <GoogleButton>
-          <CommonStyleImg src={GOOGLE_ICON} alt='' />
-          구글 계정으로 로그인
-        </GoogleButton>
-        <FacebookButton>
-          <CommonStyleImg src={FACEBOOK_ICON} alt='' />
-          페이스북 계정으로 로그인
-        </FacebookButton>
-        <Ul>
-          <EmailLoginLi>
-            <button type='button'>이메일로 로그인</button>
-          </EmailLoginLi>
-          <JoinLi>
-            <a href='/join'>회원가입</a>
-          </JoinLi>
-        </Ul>
-      </LoginSection>
-    </Main>
+    <>
+      <Main>
+        <LogoHeadingWrapper>
+          <LogoHeadingOne>
+            <LogoImg src={LOGO_WHITE_IMAGE} alt='가져도댕냥 로고' />
+          </LogoHeadingOne>
+        </LogoHeadingWrapper>
+        <LoginSection>
+          <KakaoButton>
+            <CommonStyleImg src={KAKAO_ICON} alt='' />
+            카카오 계정으로 로그인
+          </KakaoButton>
+          <GoogleButton>
+            <CommonStyleImg src={GOOGLE_ICON} alt='' />
+            구글 계정으로 로그인
+          </GoogleButton>
+          <FacebookButton>
+            <CommonStyleImg src={FACEBOOK_ICON} alt='' />
+            페이스북 계정으로 로그인
+          </FacebookButton>
+          <Ul>
+            <EmailLoginLi>
+              <Link to='/login'>이메일로 로그인</Link>
+            </EmailLoginLi>
+            <JoinLi>
+              <Link to='/join'>회원가입</Link>
+            </JoinLi>
+          </Ul>
+        </LoginSection>
+      </Main>
+    </>
   );
 };
 

--- a/src/pages/LoginMainPage/LoginMainPage.jsx
+++ b/src/pages/LoginMainPage/LoginMainPage.jsx
@@ -1,13 +1,16 @@
 import styled from 'styled-components';
 import { LOGO_WHITE_IMAGE } from '../../styles/CommonImages';
 import { KAKAO_ICON, GOOGLE_ICON, FACEBOOK_ICON } from '../../styles/CommonIcons';
+import { fadeIn } from '../../components/common/Animation/Animation';
 
 const LoginMainPage = () => {
   return (
     <Main>
-      <LogoHeadingOne>
-        <LogoImg src={LOGO_WHITE_IMAGE} alt='가져도댕냥 로고' />
-      </LogoHeadingOne>
+      <LogoHeadingWrapper>
+        <LogoHeadingOne>
+          <LogoImg src={LOGO_WHITE_IMAGE} alt='가져도댕냥 로고' />
+        </LogoHeadingOne>
+      </LogoHeadingWrapper>
       <LoginSection>
         <KakaoButton>
           <CommonStyleImg src={KAKAO_ICON} alt='' />
@@ -38,19 +41,29 @@ export default LoginMainPage;
 
 const Main = styled.main`
   position: relative;
+  display: flex;
   width: 100%;
   height: 100vh;
   background-color: var(--login-bg-color);
+  animation: ${fadeIn} 200ms linear;
+`;
+
+const LogoHeadingWrapper = styled.div`
+  width: 100%;
+  margin-bottom: 319px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 const LogoHeadingOne = styled.h1`
   width: 160px;
   height: 160px;
-  margin: 17.1rem 0 0 13rem;
 `;
 
 const LogoImg = styled.img`
   width: 100%;
+  margin-left: 15px;
 `;
 
 const LoginSection = styled.section`

--- a/src/pages/SplashScreen/SplashScreen.jsx
+++ b/src/pages/SplashScreen/SplashScreen.jsx
@@ -1,9 +1,19 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import { fadeOut } from '../../components/common/Animation/Animation';
 
 import { LOGO_IMAGE, MAIN_TITLE_IMAGE, SUB_TITLE_IMAGE } from '../../styles/CommonImages';
 
 const SplashScreen = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    setTimeout(() => {
+      navigate('/login');
+    }, 1400);
+  });
+
   return (
     <SplashScreenDiv>
       <SubTitleImg src={SUB_TITLE_IMAGE} alt='우리집 댕냥이를 위한 따뜻한 선물' />
@@ -21,6 +31,8 @@ const SplashScreenDiv = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  animation: ${fadeOut} 1400ms linear;
+  animation-fill-mode: forwards;
 `;
 
 const SubTitleImg = styled.img`

--- a/src/pages/SplashScreen/SplashScreen.jsx
+++ b/src/pages/SplashScreen/SplashScreen.jsx
@@ -1,25 +1,35 @@
-import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { fadeOut } from '../../components/common/Animation/Animation';
 
 import { LOGO_IMAGE, MAIN_TITLE_IMAGE, SUB_TITLE_IMAGE } from '../../styles/CommonImages';
+import LoginMainPage from '../LoginMainPage/LoginMainPage';
 
 const SplashScreen = () => {
-  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    setTimeout(() => {
-      navigate('/login');
+    let timer = setTimeout(() => {
+      setIsLoading(false);
     }, 1400);
-  });
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, []);
 
   return (
-    <SplashScreenDiv>
-      <SubTitleImg src={SUB_TITLE_IMAGE} alt='우리집 댕냥이를 위한 따뜻한 선물' />
-      <MainLogoImg src={LOGO_IMAGE} alt='가져도댕냥 로고' />
-      <MainTitleImg src={MAIN_TITLE_IMAGE} alt='가져도댕냥' />
-    </SplashScreenDiv>
+    <>
+      {isLoading ? (
+        <SplashScreenDiv>
+          <SubTitleImg src={SUB_TITLE_IMAGE} alt='우리집 댕냥이를 위한 따뜻한 선물' />
+          <MainLogoImg src={LOGO_IMAGE} alt='가져도댕냥 로고' />
+          <MainTitleImg src={MAIN_TITLE_IMAGE} alt='가져도댕냥' />
+        </SplashScreenDiv>
+      ) : (
+        <LoginMainPage />
+      )}
+    </>
   );
 };
 

--- a/src/pages/SplashScreen/SplashScreen.jsx
+++ b/src/pages/SplashScreen/SplashScreen.jsx
@@ -11,7 +11,7 @@ const SplashScreen = () => {
   useEffect(() => {
     let timer = setTimeout(() => {
       setIsLoading(false);
-    }, 1400);
+    }, 1500);
 
     return () => {
       clearTimeout(timer);
@@ -41,7 +41,7 @@ const SplashScreenDiv = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  animation: ${fadeOut} 1400ms linear;
+  animation: ${fadeOut} 1500ms linear;
   animation-fill-mode: forwards;
 `;
 

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -4,10 +4,10 @@ import CommunityHospitalDetailPage from '../pages/communityPage/communityHospita
 import CommunityHospitaMainlPage from '../pages/communityPage/communityHospitalPage/CommunityHospitalMainPage/CommunityHospitaMainlPage';
 import CommunityMainPage from '../pages/communityPage/CommunityMainPage/CommunityMainPage';
 import CommunityWeatherPage from '../pages/communityPage/CommunityWeatherPage/CommunityWeatherPage';
+import EmailLoginPage from '../pages/EmailLoginPage/EmailLoginPage';
 import FeedPage from '../pages/FeedPage/FeedPage';
 import FollowListPage from '../pages/FollowListPage/FollowListPage';
 import JoinMembershipPage from '../pages/JoinMembershipPage/JoinMembershipPage';
-import LoginMainPage from '../pages/LoginMainPage/LoginMainPage';
 import PostDetailPage from '../pages/PostDetailPage/PostDetailPage';
 import PostUploadPage from '../pages/PostUploadPage/PostUploadPage';
 import ProductRegistrationPage from '../pages/ProductRegistrationPage/ProductRegistrationPage';
@@ -21,7 +21,7 @@ const Router = () => {
     <Routes>
       {/* 비회원도 진입 페이지 */}
       <Route path='/' element={<SplashScreen />} />
-      <Route path='/login' element={<LoginMainPage />} />
+      <Route path='/login' element={<EmailLoginPage />} />
       <Route path='/join' element={<JoinMembershipPage />} />
       {/* 회원만 진입 가능 페이지 */}
       <Route path='/home' element={<FeedPage />} />


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- SplashPage에서 LoginMainPage로 자동 이동되는 기능을 추가했습니다.


## 기대 결과
- SplashPage에서 1.5초 후 LoginMainPage로 자동 이동


## 리뷰어에게 전달 사항
- LoginMainPage에 애니메이션을 추가하면서 냥그리 위치도 항상 가운데에 고정되도록 조절했습니다.
  - 위치 수정 전
   ![위치수정전](https://user-images.githubusercontent.com/105365737/208226540-74c3e400-16bd-4317-af18-5006bf4a0426.gif)
  - 위치 수정 후
  ![위치수정후](https://user-images.githubusercontent.com/105365737/208226543-6897673f-6ca3-4f4c-a126-0d631116f5b0.gif)
위치 수정 후

## 스크린샷
- SplashPage에서 LoginMainPage로 자동 이동 기능
  - 같은 경로('/') 내에서 이동. isLoading의 상태를 이용해 구현
![Dec-17-2022 18-26-48](https://user-images.githubusercontent.com/105365737/208235349-8626a5f7-3ee1-4b10-a401-c9e54f6a5bee.gif)



## 관련 이슈 번호
close : #170 
