### PR TITLE
style: scale-down한 이미지를 보여주기 위한 코드 추가 (#174)

### DIFF
--- a/src/components/common/ProfileImage/ProfileImage.jsx
+++ b/src/components/common/ProfileImage/ProfileImage.jsx
@@ -19,4 +19,6 @@ const Image = styled.img`
   border: ${(props) => props.borderWeight}px solid var(--profile-border-color);
   border-radius: 50%;
   cursor: ${(props) => (props.isPointer ? 'pointer' : 'default')};
+  // IE 미지원
+  object-fit: scale-down;
 `;


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [x] 기타


## 왜 코드를 추가/변경하였나요?
- scale-down한 이미지를 보여주기 위한 코드 추가를 위해서


## 기대 결과
- 이미지 size에 대응하여 이미지를 보여줄 수 있습니다.


## 리뷰어에게 전달 사항
- object-fit: scale-down; // IE 미지원


## 관련 이슈 번호
close : #174 
