### PR TITLE
feat: TabMenu 채팅 메뉴와 채팅 목록 페이지 연결 (#176)

### DIFF
--- a/src/pages/chatListPage/ChatList.jsx
+++ b/src/pages/chatListPage/ChatList.jsx
@@ -12,7 +12,7 @@ const ChatList = ({ name, content, date }) => {
         <NewMeassageAlert />
         <ChatContents className='ellipsis'>
           <strong>{name}</strong>
-          <span>{content}</span>
+          <span className='ellipsis'>{content}</span>
         </ChatContents>
         <ChatDate>{date}</ChatDate>
       </ChatLi>
@@ -54,6 +54,7 @@ const ChatContents = styled.div`
   }
 
   & span {
+    width: 100%;
     font-size: 1.2em;
     color: var(--sub-text-color);
   }

--- a/src/pages/chatListPage/ChatListPage.jsx
+++ b/src/pages/chatListPage/ChatListPage.jsx
@@ -24,7 +24,7 @@ const ChatListPage = () => {
           </Link>
         </ChatUl>
       </ContentsLayout>
-      <TabMenu />
+      <TabMenu currentMenuId={1} />
     </>
   );
 };


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- TabMenu 채팅 메뉴와 채팅 목록 페이지 연결


## 기대 결과
- TabMenu에서 채팅 메뉴를 누르면 채팅방 목록 페이지로 연결됩니다.


## 리뷰어에게 전달 사항
- ChatContents의 span 태그에 텍스트가 길어질 경우 말줄임이 되도록 `.ellipsis` 스타일도 적용했습니다. (.ellipsis는 global.css에 전역 스타일로 추가되어 있음)
- 드디어 모든 탭메뉴와 페이지 연결 완료! 🎉



## 관련 이슈 번호
close : #176 
