### PR TITLE
feat: 프로필 설정 페이지 기능 추가 (#173)

### DIFF
--- a/src/pages/ProfileSettingsPage/InputUserDescription.jsx
+++ b/src/pages/ProfileSettingsPage/InputUserDescription.jsx
@@ -1,0 +1,76 @@
+import React, { useRef, useState } from 'react';
+import styled from 'styled-components';
+
+// * 사용법 - 아래의 4가지 props를 전달해줘야 합니다 *
+// labelText : label에 들어갈 문구 (생략시 기본값: label)
+// inputType : input 태그의 타입 (생략시 기본값: text)
+// id : input 태그의 아이디
+// placeholder : input 태그에 적용할 placeholder
+const InputUserDescription = ({ children, labelText = 'label', inputType = 'text', id, placeholder, maxLength }) => {
+  const [inputValue, setInputValue] = useState('');
+
+  const [isShowAlert, setIsShowAlert] = useState(false);
+  const inputRef = useRef();
+
+  const handleChange = (e) => {
+    setInputValue(e.target.value);
+
+    if (e.target.value) {
+      inputRef.current.style.borderBottom = '1px solid var(--main-color)';
+    } else {
+      inputRef.current.style.borderBottom = '1px solid var(--border-color)';
+    }
+  };
+
+  return (
+    <InputWrapper>
+      <InputLabel htmlFor={id}>{labelText}</InputLabel>
+      <InputText
+        type={inputType}
+        id={id}
+        placeholder={placeholder}
+        value={inputValue}
+        onChange={handleChange}
+        ref={inputRef}
+        isShowAlert={isShowAlert}
+        autoComplete='off'
+        spellCheck='false'
+        maxLength={maxLength}
+      />
+    </InputWrapper>
+  );
+};
+
+export default InputUserDescription;
+
+const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const InputLabel = styled.label`
+  margin-bottom: 1rem;
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  color: var(--sub-text-color);
+`;
+
+const InputText = styled.input`
+  padding-bottom: 0.8rem;
+  font-size: var(--fs-md);
+  border-bottom: 1px solid ${(props) => (props.isShowAlert ? 'var(--main-color)' : 'var(--border-color)')};
+  outline: none;
+
+  &::placeholder {
+    color: var(--border-color);
+  }
+`;
+
+const InputAlert = styled.strong`
+  margin-top: 0.6rem;
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  color: var(--alert-color);
+  line-height: 14px;
+`;

--- a/src/pages/ProfileSettingsPage/InputUserDescription.jsx
+++ b/src/pages/ProfileSettingsPage/InputUserDescription.jsx
@@ -66,11 +66,3 @@ const InputText = styled.input`
     color: var(--border-color);
   }
 `;
-
-const InputAlert = styled.strong`
-  margin-top: 0.6rem;
-  font-size: var(--fs-sm);
-  font-weight: 500;
-  color: var(--alert-color);
-  line-height: 14px;
-`;

--- a/src/pages/ProfileSettingsPage/InputUserId.jsx
+++ b/src/pages/ProfileSettingsPage/InputUserId.jsx
@@ -6,16 +6,7 @@ import styled from 'styled-components';
 // inputType : input 태그의 타입 (생략시 기본값: text)
 // id : input 태그의 아이디
 // placeholder : input 태그에 적용할 placeholder
-const InputUserId = ({
-  children1,
-  children2,
-  labelText = 'label',
-  inputType = 'text',
-  id,
-  placeholder,
-  maxLength,
-  minLength = '0',
-}) => {
+const InputUserId = ({ children1, children2, labelText = 'label', inputType = 'text', id, placeholder, maxLength }) => {
   // dummyData
   const dummyData = 'test0106';
 
@@ -69,7 +60,6 @@ const InputUserId = ({
         autoComplete='off'
         spellCheck='false'
         maxLength={maxLength}
-        minLength={minLength}
       />
       {!idPatternValid && inputValue.length > 0 && <InputAlert>{children1}</InputAlert>}
       {!idValid && inputValue.length > 0 && <InputAlert>{children2}</InputAlert>}

--- a/src/pages/ProfileSettingsPage/InputUserId.jsx
+++ b/src/pages/ProfileSettingsPage/InputUserId.jsx
@@ -1,0 +1,112 @@
+import React, { useRef, useState } from 'react';
+import styled from 'styled-components';
+
+// * 사용법 - 아래의 4가지 props를 전달해줘야 합니다 *
+// labelText : label에 들어갈 문구 (생략시 기본값: label)
+// inputType : input 태그의 타입 (생략시 기본값: text)
+// id : input 태그의 아이디
+// placeholder : input 태그에 적용할 placeholder
+const InputUserId = ({
+  children1,
+  children2,
+  labelText = 'label',
+  inputType = 'text',
+  id,
+  placeholder,
+  maxLength,
+  minLength = '0',
+}) => {
+  // dummyData
+  const dummyData = 'test0106';
+
+  const [inputValue, setInputValue] = useState('');
+
+  // test
+  const [idPatternValid, setIdPatternValid] = useState(false);
+
+  const [idValid, setIdValid] = useState(true);
+
+  const [isShowAlert, setIsShowAlert] = useState(false);
+  const inputRef = useRef();
+
+  const handleChange = (e) => {
+    setInputValue(e.target.value);
+
+    if (e.target.value) {
+      inputRef.current.style.borderBottom = '1px solid var(--main-color)';
+    } else {
+      inputRef.current.style.borderBottom = '1px solid var(--border-color)';
+    }
+
+    if (e.target.value === dummyData) {
+      setIdValid(false);
+      console.log(e.target.value);
+      console.log('이미 사용중인 아이디!!');
+    } else {
+      setIdValid(true);
+    }
+
+    const regex = /^[._a-zA-z0-9]{0,10}$/;
+
+    if (regex.test(e.target.value)) {
+      setIdPatternValid(true);
+    } else {
+      setIdPatternValid(false);
+    }
+  };
+
+  return (
+    <InputWrapper>
+      <InputLabel htmlFor={id}>{labelText}</InputLabel>
+      <InputText
+        type={inputType}
+        id={id}
+        placeholder={placeholder}
+        value={inputValue}
+        onChange={handleChange}
+        ref={inputRef}
+        isShowAlert={isShowAlert}
+        autoComplete='off'
+        spellCheck='false'
+        maxLength={maxLength}
+        minLength={minLength}
+      />
+      {!idPatternValid && inputValue.length > 0 && <InputAlert>{children1}</InputAlert>}
+      {!idValid && inputValue.length > 0 && <InputAlert>{children2}</InputAlert>}
+    </InputWrapper>
+  );
+};
+
+export default InputUserId;
+
+const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const InputLabel = styled.label`
+  margin-bottom: 1rem;
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  color: var(--sub-text-color);
+`;
+
+const InputText = styled.input`
+  padding-bottom: 0.8rem;
+  font-size: var(--fs-md);
+  border-bottom: 1px solid ${(props) => (props.isShowAlert ? 'var(--main-color)' : 'var(--border-color)')};
+  outline: none;
+
+  &::placeholder {
+    color: var(--border-color);
+  }
+`;
+
+const InputAlert = styled.strong`
+  margin-top: 0.6rem;
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  color: var(--alert-color);
+  line-height: 14px;
+`;

--- a/src/pages/ProfileSettingsPage/InputUserName.jsx
+++ b/src/pages/ProfileSettingsPage/InputUserName.jsx
@@ -1,0 +1,77 @@
+import React, { useRef, useState } from 'react';
+import styled from 'styled-components';
+
+// * 사용법 - 아래의 4가지 props를 전달해줘야 합니다 *
+// labelText : label에 들어갈 문구 (생략시 기본값: label)
+// inputType : input 태그의 타입 (생략시 기본값: text)
+// id : input 태그의 아이디
+// placeholder : input 태그에 적용할 placeholder
+const InputUserName = ({ children, labelText = 'label', inputType = 'text', id, placeholder, maxLength }) => {
+  const [inputValue, setInputValue] = useState('');
+
+  const [isShowAlert, setIsShowAlert] = useState(false);
+  const inputRef = useRef();
+
+  const handleChange = (e) => {
+    setInputValue(e.target.value);
+
+    if (e.target.value) {
+      inputRef.current.style.borderBottom = '1px solid var(--main-color)';
+    } else {
+      inputRef.current.style.borderBottom = '1px solid var(--border-color)';
+    }
+  };
+
+  return (
+    <InputWrapper>
+      <InputLabel htmlFor={id}>{labelText}</InputLabel>
+      <InputText
+        type={inputType}
+        id={id}
+        placeholder={placeholder}
+        value={inputValue}
+        onChange={handleChange}
+        ref={inputRef}
+        isShowAlert={isShowAlert}
+        autoComplete='off'
+        spellCheck='false'
+        maxLength={maxLength}
+      />
+      {!(inputValue.length === 0) && inputValue.length < 2 && <InputAlert>{children}</InputAlert>}
+    </InputWrapper>
+  );
+};
+
+export default InputUserName;
+
+const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const InputLabel = styled.label`
+  margin-bottom: 1rem;
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  color: var(--sub-text-color);
+`;
+
+const InputText = styled.input`
+  padding-bottom: 0.8rem;
+  font-size: var(--fs-md);
+  border-bottom: 1px solid ${(props) => (props.isShowAlert ? 'var(--main-color)' : 'var(--border-color)')};
+  outline: none;
+
+  &::placeholder {
+    color: var(--border-color);
+  }
+`;
+
+const InputAlert = styled.strong`
+  margin-top: 0.6rem;
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  color: var(--alert-color);
+  line-height: 14px;
+`;

--- a/src/pages/ProfileSettingsPage/ProfileInfo.jsx
+++ b/src/pages/ProfileSettingsPage/ProfileInfo.jsx
@@ -1,33 +1,73 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 import ProfileImage from '../../components/common/ProfileImage/ProfileImage';
 import { PROFILE1_IMAGE } from '../../styles/CommonImages';
 import { UPLOAD_FILE_ICON } from '../../styles/CommonIcons';
-import Input from '../../components/common/Input/Input';
+import InputUserName from './InputUserName';
+import InputUserId from './InputUserId';
+import InputUserDescription from './InputUserDescription';
 
 const ProfileInfo = () => {
+  // 업로드 이미지 섬네일
+  const [thumbnailImg, setThumbnailImg] = useState('');
+
+  const onChangeInputHandler = (e) => {
+    const reader = new FileReader();
+
+    if (e.target.files[0]) {
+      reader.readAsDataURL(e.target.files[0]);
+    }
+
+    reader.onloadend = () => {
+      const thumbnailImgUrl = reader.result;
+
+      if (thumbnailImgUrl) {
+        setThumbnailImg([thumbnailImgUrl]);
+      }
+    };
+  };
+
   return (
     <>
       <label htmlFor='profileImg'>
         <WrapperImg>
-          <ProfileImage src={PROFILE1_IMAGE} alt='업로드 이미지' width='110' />
+          {thumbnailImg ? (
+            <ProfileImage src={thumbnailImg} alt='업로드 이미지' width='110' />
+          ) : (
+            <ProfileImage src={PROFILE1_IMAGE} alt='업로드 이미지' width='110' />
+          )}
           <UploadFileIconImg src={UPLOAD_FILE_ICON} alt='' />
         </WrapperImg>
       </label>
-      <input className='sr-only' type='file' id='profileImg' accept='image/*' />
+      <input onChange={onChangeInputHandler} className='sr-only' type='file' id='profileImg' accept='image/*' />
+
+      {/* {thumbnailImg ? <Img src={thumbnailImg} alt='' /> : ''} */}
+
       <Form>
-        <Input labelText='사용자 이름' inputType='text' id='userNameInput' placeholder='2~10자 이내여야 합니다.' />
-        <Input
+        <InputUserName
+          labelText='사용자 이름'
+          inputType='text'
+          id='userNameInput'
+          placeholder='2~10자 이내여야 합니다.'
+          maxLength='10'
+          children={'* 2~10자 이내여야 합니다.'}
+        />
+        <InputUserId
           labelText='계정 ID'
           inputType='text'
           id='userIdInput'
           placeholder='영문, 숫자, 특수문자(,), (_)만 사용 가능합니다.'
+          children1={'* 영문, 숫자, 밑줄 및 마침표만 사용할 수 있습니다.'}
+          children2={'* 이미 사용 중인 ID입니다.'}
+          maxLength='10'
         />
-        <Input
+        <InputUserDescription
           labelText='소개'
           inputType='text'
           id='userIntroInput'
           placeholder='자신과 판매할 상품에 대해 소개해 주세요.'
-        ></Input>
+          maxLength='25'
+        ></InputUserDescription>
       </Form>
     </>
   );


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 프로필 설정 페이지 기능 추가를 위해서



## 리뷰어에게 전달 사항
- 업로드 이미지 미리보기를 구현했습니다.
- 각 Input창을 분리했습니다. (수정 예정)
- 중복된 id검사를 dummyData를 활용해  시도했습니다.
- 특수문자 중 일부가 ( ` ), ( ^ ) 입력되어도 경고가 뜨지 않습니다. (수정 예정)


## 스크린샷
![ProfileSettingsPage](https://user-images.githubusercontent.com/112460383/208308575-fa161ada-e6b7-4815-869f-68f58e6a6956.gif)


## 관련 이슈 번호
close : #173 
