### PR TITLE
fix: token 값이 localStorage에 저장되어 있는데도 null로 인식되는 버그 (#211)

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,7 +1,7 @@
-import { createContext, useState } from 'react';
+import { createContext } from 'react';
 
 const AuthContext = createContext({
-  token: null,
+  token: localStorage.getItem('token'),
 });
 
 const AuthContextProvider = ({ children }) => {


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- token 값이 localStorage에 저장되어 있는데도 null로 인식되는 버그를 수정하기 위해 변경


## 기대 결과
- token 값이 localStorage에 이미 저장되어 있다면, 저장된 token 값을 정상적으로 가져옵니다.


## 스크린샷


## 관련 이슈 번호
close : #211 
