### PR TITLE
feat: AuthContext에 로그인한 사용자의 accountname 저장 (#227)

### DIFF
--- a/src/components/common/modal/ProfileModal/ProfileModal.jsx
+++ b/src/components/common/modal/ProfileModal/ProfileModal.jsx
@@ -7,7 +7,7 @@ import { MenuList, MenuItem } from './../Styled';
 
 const ProfileModal = ({ closeModal }) => {
   const navigate = useNavigate();
-  const { setToken } = useContext(AuthContextStore);
+  const { setToken, setAccountname } = useContext(AuthContextStore);
 
   const [isOpenAlert, setIsOpenAlert] = useState(false);
 
@@ -17,7 +17,11 @@ const ProfileModal = ({ closeModal }) => {
 
   const logout = () => {
     localStorage.removeItem('token');
-    setToken('');
+    localStorage.removeItem('accountname');
+
+    setToken(null);
+    setAccountname(null);
+
     navigate('/');
   };
 

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -2,13 +2,20 @@ import { createContext, useState } from 'react';
 
 export const AuthContextStore = createContext({
   token: localStorage.getItem('token') || null,
+  accountname: localStorage.getItem('accountname') || null,
   setToken: () => {},
+  setAccountname: () => {},
 });
 
 const AuthContext = ({ children }) => {
   const [token, setToken] = useState(localStorage.getItem('token') || null);
+  const [accountname, setAccountname] = useState(localStorage.getItem('accountname') || null);
 
-  return <AuthContextStore.Provider value={{ token, setToken }}>{children}</AuthContextStore.Provider>;
+  return (
+    <AuthContextStore.Provider value={{ token, setToken, accountname, setAccountname }}>
+      {children}
+    </AuthContextStore.Provider>
+  );
 };
 
 export default AuthContext;

--- a/src/pages/EmailLoginPage/EmailLoginPage.jsx
+++ b/src/pages/EmailLoginPage/EmailLoginPage.jsx
@@ -9,7 +9,7 @@ import { AuthContextStore } from '../../context/AuthContext';
 
 const EmailLoginPage = () => {
   const navigate = useNavigate();
-  const { setToken } = useContext(AuthContextStore);
+  const { setToken, setAccountname } = useContext(AuthContextStore);
 
   const [loginFail, setLoginFail] = useState(false);
   const emailInputRef = useRef();
@@ -76,7 +76,7 @@ const EmailLoginPage = () => {
           return;
         }
 
-        saveToken(res);
+        saveUserInfo(res);
         goHome();
       })
       .catch((err) => {
@@ -84,13 +84,15 @@ const EmailLoginPage = () => {
       });
   };
 
-  const saveToken = (res) => {
+  const saveUserInfo = (res) => {
     const token = res.data.user.token;
+    const accountname = res.data.user.accountname;
 
-    if (token) {
-      localStorage.setItem('token', token);
-      setToken(token);
-    }
+    localStorage.setItem('token', token);
+    localStorage.setItem('accountname', accountname);
+
+    setToken(token);
+    setAccountname(accountname);
   };
 
   const goHome = () => {


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- AuthContext에 로그인한 사용자의 accountname 저장


## 기대 결과
- 로그인시 로컬스토리지와 context에 accountname 값이 추가됩니다.
- 로그아웃시 로컬스토리지와 context에 accountname 값이 초기화됩니다.


## 관련 이슈 번호
close : #227 
