### PR TITLE
style: url 파라미터와 구분을 위해 AuthContext내 변수명 수정 (#229)

### DIFF
--- a/src/components/common/modal/ProfileModal/ProfileModal.jsx
+++ b/src/components/common/modal/ProfileModal/ProfileModal.jsx
@@ -7,7 +7,7 @@ import { MenuList, MenuItem } from './../Styled';
 
 const ProfileModal = ({ closeModal }) => {
   const navigate = useNavigate();
-  const { setToken, setAccountname } = useContext(AuthContextStore);
+  const { setUserToken, setUserAccountname } = useContext(AuthContextStore);
 
   const [isOpenAlert, setIsOpenAlert] = useState(false);
 
@@ -19,8 +19,8 @@ const ProfileModal = ({ closeModal }) => {
     localStorage.removeItem('token');
     localStorage.removeItem('accountname');
 
-    setToken(null);
-    setAccountname(null);
+    setUserToken(null);
+    setUserAccountname(null);
 
     navigate('/');
   };

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,18 +1,18 @@
 import { createContext, useState } from 'react';
 
 export const AuthContextStore = createContext({
-  token: localStorage.getItem('token') || null,
-  accountname: localStorage.getItem('accountname') || null,
-  setToken: () => {},
-  setAccountname: () => {},
+  userToken: localStorage.getItem('token') || null,
+  userAccountname: localStorage.getItem('accountname') || null,
+  setUserToken: () => {},
+  setUserAccountname: () => {},
 });
 
 const AuthContext = ({ children }) => {
-  const [token, setToken] = useState(localStorage.getItem('token') || null);
-  const [accountname, setAccountname] = useState(localStorage.getItem('accountname') || null);
+  const [userToken, setUserToken] = useState(localStorage.getItem('token') || null);
+  const [userAccountname, setUserAccountname] = useState(localStorage.getItem('accountname') || null);
 
   return (
-    <AuthContextStore.Provider value={{ token, setToken, accountname, setAccountname }}>
+    <AuthContextStore.Provider value={{ userToken, setUserToken, userAccountname, setUserAccountname }}>
       {children}
     </AuthContextStore.Provider>
   );

--- a/src/pages/EmailLoginPage/EmailLoginPage.jsx
+++ b/src/pages/EmailLoginPage/EmailLoginPage.jsx
@@ -9,7 +9,7 @@ import { AuthContextStore } from '../../context/AuthContext';
 
 const EmailLoginPage = () => {
   const navigate = useNavigate();
-  const { setToken, setAccountname } = useContext(AuthContextStore);
+  const { setUserToken, setUserAccountname } = useContext(AuthContextStore);
 
   const [loginFail, setLoginFail] = useState(false);
   const emailInputRef = useRef();
@@ -91,8 +91,8 @@ const EmailLoginPage = () => {
     localStorage.setItem('token', token);
     localStorage.setItem('accountname', accountname);
 
-    setToken(token);
-    setAccountname(accountname);
+    setUserToken(token);
+    setUserAccountname(accountname);
   };
 
   const goHome = () => {

--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -17,20 +17,20 @@ const FeedPage = () => {
 
   const url = 'https://mandarin.api.weniv.co.kr';
   // const tempToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzOWZiYWY0MTdhZTY2NjU4MWM3MzAyMSIsImV4cCI6MTY3NjU5NzIyMSwiaWF0IjoxNjcxNDEzMjIxfQ.H7gXKkMJDOyb0qO3_Zj-aDyFfzIWmVQdeCsyvQ9FEcY`;
-  const { token } = useContext(AuthContextStore);
+  const { userToken } = useContext(AuthContextStore);
 
   const goSearch = () => {
     navigate('/search');
   };
 
   useEffect(() => {
-    if (token) {
+    if (userToken) {
       const getUserFeed = async () => {
         const option = {
           url: url + `/post/feed`,
           method: 'GET',
           headers: {
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${userToken}`,
             'Content-type': 'application/json',
           },
         };
@@ -45,7 +45,7 @@ const FeedPage = () => {
 
       getUserFeed();
     }
-  }, [token]);
+  }, [userToken]);
 
   return (
     <>

--- a/src/pages/ProductRegistrationPage/ProductRegistrationPage.jsx
+++ b/src/pages/ProductRegistrationPage/ProductRegistrationPage.jsx
@@ -27,14 +27,14 @@ const ProductRegistrationPage = () => {
 
   const [itemImage, setItemImage] = useState('');
 
-  const { token } = useContext(AuthContextStore);
+  const { userToken } = useContext(AuthContextStore);
 
   const productRegistration = () => {
     const option = {
       url: 'https://mandarin.api.weniv.co.kr/product',
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${userToken}`,
         'Content-type': 'application/json',
       },
       data: {


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [x] 기타


## 왜 코드를 추가/변경하였나요?
- url 파라미터와 구분을 위해 AuthContext내 변수명을 수정했습니다.
  - url 파라미터도 accountname, AuthContext에 사용자 아이디를 저장하는 변수명도 accountname으로 구분이 어려웠음


## 기대 결과
- `token => userToken`, `accountname => userAccountname`으로 변경


## 리뷰어에게 전달 사항
- AuthContext 안에 저장된 토큰 사용 시 `${userToken}`과 같이 사용하셔야 합니다.
- AuthContext 안에 저장된 accountname 사용 시 `${userAccountname}`과 같이 사용하셔야 합니다.
- develop 브랜치에 머지된 파일엔 위 수정 사항을 반영했습니다.

## 관련 이슈 번호
close : #229 
