### PR TITLE
feat: 버튼 상태관리와 페이지 이동 기능 구현 (#236)

### DIFF
--- a/src/pages/ProductRegistrationPage/ProductRegistrationPage.jsx
+++ b/src/pages/ProductRegistrationPage/ProductRegistrationPage.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useContext } from 'react';
+import { Link } from 'react-router-dom';
 import axios from 'axios';
 import styled from 'styled-components';
 import TopUploadNav from '../../components/common/TopNavBar/TopUploadNav';
@@ -28,6 +29,8 @@ const ProductRegistrationPage = () => {
   const [itemImage, setItemImage] = useState('');
 
   const { token } = useContext(AuthContextStore);
+
+  const [disabledButton, setDisabledButton] = useState(true);
 
   const productRegistration = () => {
     const option = {
@@ -77,9 +80,20 @@ const ProductRegistrationPage = () => {
     };
   };
 
+  // 버튼 활성화
+  useEffect(() => {
+    if (itemName && price && link && thumbnailImg) {
+      setDisabledButton(false);
+    }
+    console.log('render!!');
+  }, [thumbnailImg, itemName, price, link]);
+
   return (
     <>
-      <TopUploadNav onClick={productRegistration} />
+      <Link to='/profile'>
+        <TopUploadNav activeButton={disabledButton} onClick={productRegistration} />
+      </Link>
+
       <ContentsLayout isTabMenu='false' padding='0'>
         <Section>
           <h2 className='sr-only'>상품 정보</h2>


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 버튼 상태관리와 페이지 이동 기능 구현을 위해서


## 기대 결과
- 이미지 등록, 상품명, 가격, 판매 링크 모두 입력되어야 버튼이 활성화 됩니다.
- 입력 후 저장 버튼을 누르면 이전 페이지로 이동합니다. /product >> /profile


## 리뷰어에게 전달 사항
- 수정 사항이 생길 수 있습니다.



## 스크린샷
![ProductRegistrationPage_2](https://user-images.githubusercontent.com/112460383/208593910-1cf22042-37de-400f-b375-c605f712ca56.gif)


## 관련 이슈 번호
close : #236 
