### PR TITLE
feat: 팔로우 리스트 조회 및 팔로우/팔로우 취소 기능 구현 (#220)

### DIFF
--- a/src/components/common/userItem/Follow/Follow.jsx
+++ b/src/components/common/userItem/Follow/Follow.jsx
@@ -1,24 +1,47 @@
-import React, { useState } from 'react';
+import axios from 'axios';
+import React, { useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
+import { AuthContextStore } from '../../../../context/AuthContext';
 import Button from '../../Button/Button';
-import UserAccountInfo from '../UserAccountInfo/UserAccountInfo';
+import FollowUserInfo from '../UserAccountInfo/FollowUserInfo';
 
-const Follow = () => {
-  const [isClickCancle, setIsClickCancle] = useState(false);
+const Follow = ({ followUserInfo }) => {
+  const [isFollow, setIsFollow] = useState(followUserInfo.isfollow);
+  const { userToken, userAccountname } = useContext(AuthContextStore);
+
+  const switchFollow = async () => {
+    const option = {
+      url: `https://mandarin.api.weniv.co.kr/profile/${followUserInfo.accountname}/${isFollow ? 'unfollow' : 'follow'}`,
+      method: isFollow ? 'DELETE' : 'POST',
+      headers: { Authorization: `Bearer ${userToken}`, 'Content-type': 'application/json' },
+    };
+
+    await axios(option)
+      .then((res) => {
+        setIsFollow(!isFollow);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  };
 
   return (
     <UserItem>
-      <UserAccountInfo />
+      <FollowUserInfo followUserInfo={followUserInfo} />
 
-      <Button
-        size='S'
-        backgroundColor={isClickCancle ? 'var(--main-bg-color)' : undefined}
-        borderColor={isClickCancle ? 'var(--border-color)' : undefined}
-        textColor={isClickCancle ? 'var(--sub-text-color)' : undefined}
-        onClickHandler={() => setIsClickCancle(!isClickCancle)}
-      >
-        {isClickCancle ? '취소' : '팔로우'}
-      </Button>
+      {followUserInfo.accountname === userAccountname ? (
+        <></>
+      ) : (
+        <Button
+          size='S'
+          backgroundColor={isFollow ? 'var(--main-bg-color)' : undefined}
+          borderColor={isFollow ? 'var(--border-color)' : undefined}
+          textColor={isFollow ? 'var(--sub-text-color)' : undefined}
+          onClickHandler={switchFollow}
+        >
+          {isFollow ? '취소' : '팔로우'}
+        </Button>
+      )}
     </UserItem>
   );
 };

--- a/src/components/common/userItem/Follow/Follow.jsx
+++ b/src/components/common/userItem/Follow/Follow.jsx
@@ -1,9 +1,9 @@
 import axios from 'axios';
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
 import { AuthContextStore } from '../../../../context/AuthContext';
 import Button from '../../Button/Button';
-import FollowUserInfo from '../UserAccountInfo/FollowUserInfo';
+import UserAccountInfo from '../UserAccountInfo/UserAccountInfo';
 
 const Follow = ({ followUserInfo }) => {
   const [isFollow, setIsFollow] = useState(followUserInfo.isfollow);
@@ -27,7 +27,11 @@ const Follow = ({ followUserInfo }) => {
 
   return (
     <UserItem>
-      <FollowUserInfo followUserInfo={followUserInfo} />
+      <UserAccountInfo
+        accountname={followUserInfo.accountname}
+        username={followUserInfo.username}
+        image={followUserInfo.image}
+      />
 
       {followUserInfo.accountname === userAccountname ? (
         <></>

--- a/src/components/common/userItem/UserAccountInfo/UserAccountInfo.jsx
+++ b/src/components/common/userItem/UserAccountInfo/UserAccountInfo.jsx
@@ -11,7 +11,7 @@ const UserAccountInfo = ({ keyword = '', accountname, username, image }) => {
   const arrayKeyword = COMMA_APPEND_USERNAME.split(',');
 
   return (
-    <UserLink to='#'>
+    <UserLink to={`/profile/${accountname}`}>
       <ProfileImage src={image} alt={`${username}님의 프로필사진`} width='50' />
       <AccountInfoWrapper>
         <UserName>

--- a/src/pages/FollowListPage/EmptyFollowList.jsx
+++ b/src/pages/FollowListPage/EmptyFollowList.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from 'styled-components';
+import { EMPTY_POST_IMAGE } from '../../styles/CommonImages';
+
+const EmptyFollowList = ({ type }) => {
+  return (
+    <EmptyContents>
+      <EmptyImage src={EMPTY_POST_IMAGE} alt='' />
+      <EmptyText>아직 {type === 'follower' ? '팔로워가' : '팔로우한 사용자가'} 없어요.</EmptyText>
+    </EmptyContents>
+  );
+};
+
+export default EmptyFollowList;
+
+const EmptyContents = styled.div`
+  position: fixed;
+  top: 45%;
+  left: 50%;
+  transform: translate(-50%, -45%);
+  text-align: center;
+`;
+
+const EmptyImage = styled.img`
+  width: 160px;
+  height: 160px;
+  margin: 0 auto 2rem;
+`;
+
+const EmptyText = styled.strong`
+  font-size: var(--fs-md);
+  color: var(--sub-text-color);
+`;

--- a/src/pages/FollowListPage/FollowListPage.jsx
+++ b/src/pages/FollowListPage/FollowListPage.jsx
@@ -32,7 +32,6 @@ const FollowListPage = () => {
         return;
       }
 
-      // TODO: 비동기 통신 코드 작성
       const option = {
         url: `https://mandarin.api.weniv.co.kr/profile/${accountname}/${type}`,
         method: 'GET',

--- a/src/pages/FollowListPage/FollowListPage.jsx
+++ b/src/pages/FollowListPage/FollowListPage.jsx
@@ -1,31 +1,98 @@
-import React, { useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import axios from 'axios';
+import { AuthContextStore } from '../../context/AuthContext';
 import TopTitleNav from '../../components/common/TopNavBar/TopTitleNav';
 import TabMenu from '../../components/common/TabMenu/TabMenu';
 import ContentsLayout from '../../components/layout/ContentsLayout/ContentsLayout';
 import Follow from '../../components/common/userItem/Follow/Follow';
 import styled from 'styled-components';
+import EmptyFollowList from './EmptyFollowList';
+import Loading from '../../components/common/Loading/Loading';
 
 const FollowListPage = () => {
+  const [isLoading, setIsLoading] = useState(true);
+  const { accountname, type } = useParams();
+  const { userToken } = useContext(AuthContextStore);
+  const [followList, setFollowList] = useState([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const getFollowList = async () => {
+      try {
+        if (!accountname || !type) {
+          throw new Error('PATH_ERROR');
+        }
+
+        if (type !== 'follower' && type !== 'following') {
+          throw new Error('PATH_ERROR');
+        }
+      } catch (err) {
+        navigate('/notfound');
+        return;
+      }
+
+      // TODO: 비동기 통신 코드 작성
+      const option = {
+        url: `https://mandarin.api.weniv.co.kr/profile/${accountname}/${type}`,
+        method: 'GET',
+        headers: { Authorization: `Bearer ${userToken}`, 'Content-type': 'application/json' },
+      };
+
+      await axios(option)
+        .then((res) => {
+          setIsLoading(false);
+          setFollowList(res.data);
+        })
+        .catch((err) => {
+          setIsLoading(false);
+
+          if (err === '404' || err.response.status === 404) {
+            navigate('/notfound');
+            return;
+          }
+
+          console.error(err);
+        });
+    };
+
+    getFollowList();
+  }, []);
+
   return (
     <>
-      <TopTitleNav title='Followers' />
-      <ContentsLayout padding='2.4rem 1.6rem'>
-        <FollowList>
-          <Follow />
-          <Follow />
-          <Follow />
-          <Follow />
-          <Follow />
-          <Follow />
-          <Follow />
-        </FollowList>
-      </ContentsLayout>
+      <TopTitleNav title={type === 'follower' ? 'Followers' : 'Followings'} viewMoreBtn={false} />
+      {isLoading ? (
+        <LoadingWrapper>
+          <Loading />
+        </LoadingWrapper>
+      ) : (
+        <ContentsLayout padding='2.4rem 1.6rem'>
+          {followList.length > 0 ? (
+            <FollowList>
+              {followList.map((followUser) => (
+                <Follow key={followUser._id} followUserInfo={followUser} />
+              ))}
+            </FollowList>
+          ) : (
+            <EmptyFollowList type={type} />
+          )}
+        </ContentsLayout>
+      )}
+
       <TabMenu currentMenuId={4} />
     </>
   );
 };
 
 export default FollowListPage;
+
+const LoadingWrapper = styled.div`
+  position: fixed;
+  top: 45%;
+  left: 50%;
+  transform: translate(-50%, -45%);
+`;
 
 const FollowList = styled.ul`
   & > li:not(:last-of-type) {


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 팔로우 리스트 조회 및 팔로우/취소 기능을 구현하기 위해 추가했습니다.


## 기대 결과
- accountname 파라미터와 type 파라미터를 제대로 전달하면 팔로우 목록이 출력됩니다.
- accountname 파라미터와 type 파라미터 중 하나라도 정상적이지 않으면 404 페이지로 이동됩니다.
- 팔로잉, 팔로워 목록 조회가 가능합니다.
- 팔로우 버튼을 통해 팔로우/팔로우 취소가 가능합니다.
- 자신의 계정일때는 팔로우 버튼이 나타나지 않습니다.
- 사용자 리스트를 클릭하면 해당 사용자의 프로필로 이동합니다.

## 테스트 케이스
### 1. accountname 파라미터에 존재하지 않는 계정명을 입력했을 때
- 기대 결과 : 404 페이지로 이동
- 테스트 결과 : pass
![아이디에러](https://user-images.githubusercontent.com/105365737/208605235-c02929a2-dc00-4921-8dae-3cd3b7f5301b.gif)

### 2. type 파라미터에 follower나 following이 아닌 값을 입력했을 때
- 기대 결과 : 404 페이지로 이동
- 테스트 결과 : pass
![type에러](https://user-images.githubusercontent.com/105365737/208604976-ecf7985c-1319-478e-968e-2bebec7e1621.gif)

### 3. accountname이나 type 파라미터의 값을 누락했을 때
- 기대 결과 : 404 페이지로 이동
- 테스트 결과 : pass
![값 누락](https://user-images.githubusercontent.com/105365737/208605123-44e39390-3406-4e1c-96ca-b78d550c6e73.gif)

### 4. 팔로잉한 사용자가 있을 때
- 기대 결과 : 팔로잉 목록 출력. 헤더 타이틀 Followings
- 테스트 결과 : pass
![스크린샷 2022-12-20 오후 4 08 01](https://user-images.githubusercontent.com/105365737/208604654-824c21c2-8e54-4687-9fa8-34c676f55f75.png)

### 5. 팔로잉한 사용자가 없을 때
- 기대 결과 : '아직 팔로우한 사용자가 없어요.' 문구 출력. 헤더 타이틀 Followings
- 테스트 결과 : pass
<img width="901" alt="스크린샷 2022-12-20 오후 3 43 56" src="https://user-images.githubusercontent.com/105365737/208604392-8a7a430b-5238-4a4d-a4af-75ec4ca1c6b6.png">

### 6. 팔로워가 있을 때
- 기대 결과 : 팔로워 목록 출력. 헤더 타이틀 Followers
- 테스트 결과 : pass
![스크린샷 2022-12-20 오후 4 14 15](https://user-images.githubusercontent.com/105365737/208605766-a707e7e5-8762-46b2-897b-3f8d83ac192e.png)

### 7. 팔로워가 없을 때
- 기대 결과 : '아직 팔로워가 없어요.' 문구 출력. 헤더 타이틀 Followers
- 테스트 결과 : pass
<img width="915" alt="스크린샷 2022-12-20 오후 3 43 05" src="https://user-images.githubusercontent.com/105365737/208604321-12eb2671-cae8-4a32-97f1-59e94b446621.png">

### 8. 팔로우/취소 버튼 동작 확인
- 기대 결과 : 팔로우 버튼을 누르면 팔로우, 취소 버튼을 누르면 팔로우 취소
- 테스트 결과 : pass
- **특이사항 : 버튼 클릭 시 버튼이 반짝거리는 현상이 있으나 Button 컴포넌트의 &:active 속성 때문인 것으로 확인. 기능에는 문제 없으니 이번 단계에선 pass 처리**
![팔로우취소](https://user-images.githubusercontent.com/105365737/208605368-742a539e-4f5d-45ff-ab52-beb967e8a128.gif)

### 9. 팔로우 목록에 '내'가 있을 때
- 기대 결과 : 팔로우/취소 버튼 미출력
- 테스트 결과 : pass
<img width="745" alt="스크린샷 2022-12-20 오후 3 52 48" src="https://user-images.githubusercontent.com/105365737/208604783-7061e38f-b314-4782-9f22-fcf6b77963e9.png">

## 관련 이슈 번호
close : #220 
