### PR TITLE
feat: Post 컴포넌트에 서버 데이터 출력 (#246)

### DIFF
--- a/src/components/common/Post/Post.jsx
+++ b/src/components/common/Post/Post.jsx
@@ -4,14 +4,20 @@ import ProfileImage from '../ProfileImage/ProfileImage';
 import { PROFILE1_IMAGE } from '../../../styles/CommonImages';
 import { MORE_SMALL_ICON, HEART_ICON, HEART_FILL_ICON, REPLY_ICON } from '../../../styles/CommonIcons';
 import PostModal from '../modal/PostModal/PostModal';
+import { Link, useNavigate } from 'react-router-dom';
 
-const Post = ({ userName, userId, content, img }) => {
+const Post = ({ post = {} }) => {
+  const navigate = useNavigate();
+
+  const year = new Date(post.createdAt).getFullYear();
+  const month = new Date(post.createdAt).getMonth() + 1;
+  const date = new Date(post.createdAt).getDate();
+
   const [isOpenModal, setIsOpenModal] = useState(false);
   const [isMyPost, setIsMyPost] = useState(true); // 내 게시글인 경우 true, 다른 사람의 게시글인 경우 false가 들어갑니다. (true인 경우 - 삭제/수정 출력, false인 경우 - 신고 출력)
 
-  const [contentImg, setContentImg] = useState(img);
-
   const [like, setLike] = useState(false);
+
   const onClickLikeButtonHandler = () => {
     setLike(!like);
   };
@@ -22,39 +28,53 @@ const Post = ({ userName, userId, content, img }) => {
 
   return (
     <>
-      <WrapperDiv>
-        <UserInfoWrapperDiv>
-          <ProfileImage src={PROFILE1_IMAGE} alt='프로필 이미지' width='42' />
-          <UserInfoDiv>
-            <UserName>{userName}</UserName>
-            <UserId>{userId}</UserId>
-          </UserInfoDiv>
-          <MoreSmallButton onClick={() => setIsOpenModal(true)}>
-            <img src={MORE_SMALL_ICON} alt='더보기' />
-          </MoreSmallButton>
-        </UserInfoWrapperDiv>
-        <ContentWrapperDiv>
-          <ContentText>{content}</ContentText>
-          {contentImg === true ? <ContentImg src={img} alt='프로필 이미지' /> : <></>}
-          <Div>
-            <LikeButton like={like} onClick={onClickLikeButtonHandler}>
-              <span className='sr-only'>{like ? '좋아요 취소' : '좋아요'}</span>
-            </LikeButton>
-            <LikeSpan>0</LikeSpan>
-            <ChatImg src={REPLY_ICON} alt='채팅' />
-            <ChatSpan>0</ChatSpan>
-          </Div>
-          <DateP>2023년 1월 6일</DateP>
-        </ContentWrapperDiv>
-      </WrapperDiv>
-      {isOpenModal ? <PostModal closeModal={closeModal} isMyPost={isMyPost} /> : <></>}
+      {Object.keys(post).length > 0 ? (
+        <>
+          <WrapperDiv>
+            <UserInfoWrapperDiv>
+              <UserProfileLink to={`/profile/${post.author.accountname}`}>
+                <ProfileImage src={post.author.image} alt={`${post.author.username}님의 프로필 사진`} width='42' />
+                <UserInfoDiv>
+                  <UserName>{post.author.username}</UserName>
+                  <UserId>@ {post.author.accountname}</UserId>
+                </UserInfoDiv>
+              </UserProfileLink>
+              <MoreSmallButton onClick={() => setIsOpenModal(true)}>
+                <img src={MORE_SMALL_ICON} alt='더보기' />
+              </MoreSmallButton>
+            </UserInfoWrapperDiv>
+            <ContentWrapperDiv>
+              <PostDetailLink to={`/post/${post.id}`} type='content'>
+                <ContentText>{post.content}</ContentText>
+                {post.image ? <ContentImg src={post.image} alt='' /> : <></>}
+              </PostDetailLink>
+              <Div>
+                <LikeButton like={like} onClick={onClickLikeButtonHandler}>
+                  <span className='sr-only'>{like ? '좋아요 취소' : '좋아요'}</span>
+                </LikeButton>
+                <LikeSpan>{post.heartCount}</LikeSpan>
+                <PostDetailLink to={`/post/${post.id}`} type='comment'>
+                  <ChatImg src={REPLY_ICON} alt='댓글 보기' />
+                  <ChatSpan>{post.commentCount}</ChatSpan>
+                </PostDetailLink>
+              </Div>
+              <DateP>
+                {year}년 {month}월 {date}일
+              </DateP>
+            </ContentWrapperDiv>
+          </WrapperDiv>
+          {isOpenModal ? <PostModal closeModal={closeModal} isMyPost={isMyPost} /> : <></>}
+        </>
+      ) : (
+        <></>
+      )}
     </>
   );
 };
 
 export default Post;
 
-const WrapperDiv = styled.div`
+const WrapperDiv = styled.article`
   width: 35.8rem;
   margin: 0 auto 2rem;
 `;
@@ -63,6 +83,10 @@ const UserInfoWrapperDiv = styled.div`
   display: flex;
   position: relative;
   cursor: pointer;
+`;
+
+const UserProfileLink = styled(Link)`
+  display: flex;
 `;
 
 const UserInfoDiv = styled.div`
@@ -128,6 +152,11 @@ const LikeSpan = styled.span`
   font-size: var(--fs-sm);
   line-height: 1.8rem;
   color: var(--sub-text-color);
+`;
+
+const PostDetailLink = styled(Link)`
+  display: flex;
+  ${(props) => (props.type === 'content' ? 'flex-direction: column' : '')}
 `;
 
 const ChatImg = styled.img`

--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -10,10 +10,12 @@ import TabMenu from '../.././components/common/TabMenu/TabMenu';
 import Button from '../../components/common/Button/Button';
 import Post from '../../components/common/Post/Post';
 import { EMPTY_FEED_IMAGE } from '../.././styles/CommonImages';
+import Loading from '../../components/common/Loading/Loading';
 
 const FeedPage = () => {
   const navigate = useNavigate();
   const [isFollowingPost, setIsFollowingPost] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   const url = 'https://mandarin.api.weniv.co.kr';
   // const tempToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzOWZiYWY0MTdhZTY2NjU4MWM3MzAyMSIsImV4cCI6MTY3NjU5NzIyMSwiaWF0IjoxNjcxNDEzMjIxfQ.H7gXKkMJDOyb0qO3_Zj-aDyFfzIWmVQdeCsyvQ9FEcY`;
@@ -37,10 +39,13 @@ const FeedPage = () => {
 
         await axios(option)
           .then((res) => {
+            setIsLoading(false);
             setIsFollowingPost(res.data.posts);
-            // console.log(res);
           })
-          .catch((err) => console.error(err));
+          .catch((err) => {
+            setIsLoading(false);
+            console.error(err);
+          });
       };
 
       getUserFeed();
@@ -49,43 +54,51 @@ const FeedPage = () => {
 
   return (
     <>
-      <TopMainNav title={'가져도댕냥 피드'} />
-      {isFollowingPost.length > 0 ? (
-        <ContentsLayout>
-          <MainFeedStyle>
-            {isFollowingPost.map((post) => {
-              return (
-                <div key={post.id}>
-                  <Post
-                    userName={post.author.username}
-                    userId={post.author.accountname}
-                    content={post.content}
-                    img={post.image}
-                  />
-                </div>
-              );
-            })}
-          </MainFeedStyle>
-        </ContentsLayout>
+      {isLoading ? (
+        <LoadingWrapper>
+          <Loading />
+        </LoadingWrapper>
       ) : (
-        <EmptyFeedStyle>
-          <ErrorImg src={EMPTY_FEED_IMAGE} alt='에러 이미지' />
-          <span>유저를 검색해 팔로우 해보세요!</span>
-          <Button size='M' onClickHandler={goSearch}>
-            검색하기
-          </Button>
-        </EmptyFeedStyle>
+        <>
+          <TopMainNav title={'가져도댕냥 피드'} />
+          {isFollowingPost.length > 0 ? (
+            <ContentsLayout>
+              <div>
+                {isFollowingPost.map((post) => {
+                  return (
+                    <div key={post.id}>
+                      <Post post={post} />
+                    </div>
+                  );
+                })}
+              </div>
+            </ContentsLayout>
+          ) : (
+            <EmptyFeedStyle>
+              <ErrorImg src={EMPTY_FEED_IMAGE} alt='에러 이미지' />
+              <span>유저를 검색해 팔로우 해보세요!</span>
+              <Button size='M' onClickHandler={goSearch}>
+                검색하기
+              </Button>
+            </EmptyFeedStyle>
+          )}
+          <TabMenu />
+        </>
       )}
-      <TabMenu />
     </>
   );
 };
 
 export default FeedPage;
 
-const MainFeedStyle = styled.main``;
+const LoadingWrapper = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;
 
-const EmptyFeedStyle = styled.main`
+const EmptyFeedStyle = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/pages/PostDetailPage/PostDetailPage.jsx
+++ b/src/pages/PostDetailPage/PostDetailPage.jsx
@@ -7,12 +7,25 @@ import styled from 'styled-components';
 import PostComment from './PostComment';
 
 const PostDetailPage = () => {
+  const testPost = {
+    author: {
+      accountname: 'test',
+      image: 'https://mandarin.api.weniv.co.kr/Ellipse.png',
+      username: '테스트',
+    },
+    commentCount: 0,
+    content: '테스트용 객체',
+    createdAt: '2022-07-18T06:15:39.035Z',
+    heartCount: 0,
+    id: '62d4fa8b82fdcc712f4c98a5',
+  };
+
   return (
     <ContentsLayout isTabMenu={true} padding='2rem 0 0 0'>
       <TopBasicNav />
       <PostViewer>
         <h2 className='sr-only'>Post Item</h2>
-        <Post userName={'Test'} userId={'@test'} />
+        <Post post={testPost} />
       </PostViewer>
       <PostCommentList>
         <h2 className='sr-only'>PostComment</h2>

--- a/src/pages/profilePage/ProfilePost/ProfilePost.jsx
+++ b/src/pages/profilePage/ProfilePost/ProfilePost.jsx
@@ -32,6 +32,19 @@ const ProfilePost = ({ postState }) => {
     onListClicked(false);
   };
 
+  const testPost = {
+    author: {
+      accountname: 'test',
+      image: 'https://mandarin.api.weniv.co.kr/Ellipse.png',
+      username: '테스트',
+    },
+    commentCount: 0,
+    content: '테스트용 객체',
+    createdAt: '2022-07-18T06:15:39.035Z',
+    heartCount: 0,
+    id: '62d4fa8b82fdcc712f4c98a5',
+  };
+
   return (
     <>
       <h2 className='sr-only'>게시물 리스트</h2>
@@ -44,31 +57,34 @@ const ProfilePost = ({ postState }) => {
         </AlbumIcon>
       </PostHeader>
 
-      {postState ?       listBtn === true ? (
-        <PostUl>
-          <h3 className='sr-only'>리스트형 포스트 목록</h3>
-          <Post userId='@ weniv_Mandarin' userName='애월읍 위니브 감귤농장' />
-          <Post userId='@ weniv_Mandarin' userName='애월읍 위니브 감귤농장' />
-          <Post userId='@ weniv_Mandarin' userName='애월읍 위니브 감귤농장' />
-        </PostUl>
+      {postState ? (
+        listBtn === true ? (
+          <PostUl>
+            <h3 className='sr-only'>리스트형 포스트 목록</h3>
+            <Post post={testPost} />
+            <Post post={testPost} />
+            <Post post={testPost} />
+          </PostUl>
+        ) : (
+          <PostGrid>
+            <h3 className='sr-only'>앨범형 포스트 목록</h3>
+            <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
+            <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
+            <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
+            <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
+            <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
+            <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
+            <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
+            <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
+            <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
+          </PostGrid>
+        )
       ) : (
-        <PostGrid>
-          <h3 className='sr-only'>앨범형 포스트 목록</h3>
-          <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
-          <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
-          <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
-          <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
-          <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
-          <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
-          <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
-          <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
-          <img src='https://picsum.photos/250/250' alt='게시물 썸네일 이미지' />
-        </PostGrid>
-      ) : <NoPost>
-        <img src={EMPTY_POST_IMAGE} alt='포스트가 존재하지 않습니다' />
-        <span>아직 작성된 게시글이 없어요.</span>
-      </NoPost>}
-      
+        <NoPost>
+          <img src={EMPTY_POST_IMAGE} alt='포스트가 존재하지 않습니다' />
+          <span>아직 작성된 게시글이 없어요.</span>
+        </NoPost>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 서버에서 받아온 게시글 데이터를 뿌려주기 위해 Post 컴포넌트를 수정했습니다.


## 기대 결과
- 서버에서 받아온 게시글 데이터를 화면에 출력합니다.
- 날짜(createdAt)를 가공한 후 화면에 출력합니다.
- 프로필 부분을 누르면 사용자 프로필로 이동합니다.
- 컨텐츠 부분을 누르면 상세 게시글 페이지로 이동합니다.
- 댓글 버튼을 누르면 상세 게시글 페이지로 이동합니다.


## 리뷰어에게 전달 사항
- Post 컴포넌트를 쓰는 페이지 중 아직 작업중인 페이지(ProfilePage, PostDetailPage)에는 서버 응답과 유사한 형태의 테스트 데이터를 넣어놓았습니다.
- Post 컴포넌트에는 서버에게 응답받은 post 객체 자체를 넘겨주면 됩니다.


## 관련 이슈 번호
close : #246 
