### PR TITLE
feat: 프로필 수정 페이지 기능 구현 (#253)

### DIFF
--- a/src/pages/ProfileModificationPage/ProfileModificationPage.jsx
+++ b/src/pages/ProfileModificationPage/ProfileModificationPage.jsx
@@ -1,4 +1,5 @@
 import { useContext, useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import axios from 'axios';
 import styled from 'styled-components';
 import TopUploadNav from '../../components/common/TopNavBar/TopUploadNav';
@@ -51,32 +52,61 @@ const ProfileModificationPage = () => {
   };
   // console.log(image);
 
-  const test = () => {
+  const [disabledButton, setDisabledButton] = useState(false);
+
+  useEffect(() => {
+    const getInfo = () => {
+      const option = {
+        url: 'https://mandarin.api.weniv.co.kr/user/myinfo',
+        method: 'GET',
+        headers: { Authorization: `Bearer ${userToken}` },
+      };
+
+      axios(option)
+        .then((res) => {
+          console.log(res.data.user);
+          setUserName(res.data.user.username);
+          setAccountName(res.data.user.accountname);
+          setIntro(res.data.user.intro);
+          setImage(res.data.user.image);
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+    };
+    getInfo();
+  }, [userToken]);
+
+  const onClickSaveButtonHandler = () => {
     const option = {
-      url: 'https://mandarin.api.weniv.co.kr/user/myinfo',
-      method: 'GET',
-      headers: { Authorization: `Bearer ${userToken}` },
+      url: 'https://mandarin.api.weniv.co.kr/user',
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${userToken}`, 'Content-type': 'application/json' },
+      data: {
+        user: {
+          username: userName,
+          accountname: accountName,
+          intro: intro,
+          image: image,
+        },
+      },
     };
 
     axios(option)
       .then((res) => {
-        // console.log(res.data.user);
-        setUserName(res.data.user.username);
-        setAccountName(res.data.user.accountname);
-        setIntro(res.data.user.intro);
+        // console.log(res);
+        console.log('수정!!!');
       })
       .catch((err) => {
         console.error(err);
       });
   };
 
-  test();
-
-  useEffect(() => {}, [userName]);
-
   return (
     <>
-      <TopUploadNav />
+      <Link to='/profile'>
+        <TopUploadNav activeButton={disabledButton} onClick={onClickSaveButtonHandler} />
+      </Link>
       <ContentsLayout isTabMenu='false' padding='0'>
         <Section>
           <h2 className='sr-only'>프로필 정보 수정</h2>
@@ -88,6 +118,7 @@ const ProfileModificationPage = () => {
             userName={userName}
             accountName={accountName}
             intro={intro}
+            image={image}
           />
         </Section>
       </ContentsLayout>
@@ -102,8 +133,4 @@ const Section = styled.section`
   flex-direction: column;
   align-items: center;
   padding: 3rem 3.4rem 0;
-`;
-
-const Input = styled.input`
-  border: 2px solid pink;
 `;

--- a/src/pages/ProfileModificationPage/ProfileModificationPage.jsx
+++ b/src/pages/ProfileModificationPage/ProfileModificationPage.jsx
@@ -1,16 +1,94 @@
+import { useContext, useState, useEffect } from 'react';
+import axios from 'axios';
 import styled from 'styled-components';
 import TopUploadNav from '../../components/common/TopNavBar/TopUploadNav';
 import ContentsLayout from '../../components/layout/ContentsLayout/ContentsLayout';
 import ProfileInfo from '../ProfileSettingsPage/ProfileInfo';
+import { AuthContextStore } from '../../context/AuthContext';
 
 const ProfileModificationPage = () => {
+  const { userToken } = useContext(AuthContextStore);
+
+  const [userName, setUserName] = useState('');
+  const userNameFunction = (value) => {
+    setUserName(value);
+    // // 버튼 활성화
+    // if (userName && accountName && intro) {
+    //   setDisabledButton(false);
+    // } else {
+    //   setDisabledButton(true);
+    // }
+  };
+  // console.log(userName);
+
+  const [accountName, setAccountName] = useState('');
+  const accountNameFunction = (value) => {
+    setAccountName(value);
+    // 버튼 활성화
+    // if (userName && accountName && intro) {
+    //   setDisabledButton(false);
+    // } else {
+    //   setDisabledButton(true);
+    // }
+  };
+  // console.log(accountName);
+
+  const [intro, setIntro] = useState('');
+  const introFunction = (value) => {
+    setIntro(value);
+    // 버튼 활성화
+    // if (userName && accountName && intro) {
+    //   setDisabledButton(false);
+    // } else {
+    //   setDisabledButton(true);
+    // }
+  };
+  // console.log(intro);
+
+  const [image, setImage] = useState('');
+  const imageFunction = (value) => {
+    setImage(value);
+  };
+  // console.log(image);
+
+  const test = () => {
+    const option = {
+      url: 'https://mandarin.api.weniv.co.kr/user/myinfo',
+      method: 'GET',
+      headers: { Authorization: `Bearer ${userToken}` },
+    };
+
+    axios(option)
+      .then((res) => {
+        // console.log(res.data.user);
+        setUserName(res.data.user.username);
+        setAccountName(res.data.user.accountname);
+        setIntro(res.data.user.intro);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  };
+
+  test();
+
+  useEffect(() => {}, [userName]);
+
   return (
     <>
       <TopUploadNav />
       <ContentsLayout isTabMenu='false' padding='0'>
         <Section>
           <h2 className='sr-only'>프로필 정보 수정</h2>
-          <ProfileInfo />
+          <ProfileInfo
+            userNameFunction={userNameFunction}
+            accountNameFunction={accountNameFunction}
+            introFunction={introFunction}
+            imageFunction={imageFunction}
+            userName={userName}
+            accountName={accountName}
+            intro={intro}
+          />
         </Section>
       </ContentsLayout>
     </>
@@ -24,4 +102,8 @@ const Section = styled.section`
   flex-direction: column;
   align-items: center;
   padding: 3rem 3.4rem 0;
+`;
+
+const Input = styled.input`
+  border: 2px solid pink;
 `;

--- a/src/pages/ProfileModificationPage/ProfileModificationPage.jsx
+++ b/src/pages/ProfileModificationPage/ProfileModificationPage.jsx
@@ -64,7 +64,7 @@ const ProfileModificationPage = () => {
 
       axios(option)
         .then((res) => {
-          console.log(res.data.user);
+          // console.log(res.data.user);
           setUserName(res.data.user.username);
           setAccountName(res.data.user.accountname);
           setIntro(res.data.user.intro);
@@ -94,13 +94,24 @@ const ProfileModificationPage = () => {
 
     axios(option)
       .then((res) => {
-        // console.log(res);
-        console.log('수정!!!');
+        console.log('프로필 수정 성공!!');
+        console.log(res);
       })
       .catch((err) => {
         console.error(err);
       });
   };
+
+  // 버튼 활성화
+  useEffect(() => {
+    if (userName && accountName && intro) {
+      setDisabledButton(false);
+    } else {
+      setDisabledButton(true);
+    }
+    // console.log('render!!');
+    // console.log(link);
+  }, [userName, accountName, intro]);
 
   return (
     <>

--- a/src/pages/ProfileSettingsPage/InputAccountName.jsx
+++ b/src/pages/ProfileSettingsPage/InputAccountName.jsx
@@ -14,9 +14,10 @@ const InputAccountName = ({
   placeholder,
   maxLength,
   accountNameFunction,
-  disabledButtonFunction,
+  // disabledButtonFunction,
+  accountName,
 }) => {
-  const [inputValue, setInputValue] = useState('');
+  const [inputValue, setInputValue] = useState(`${accountName ? accountName : ''}`);
 
   const [isShowAlert, setIsShowAlert] = useState(false);
   const inputRef = useRef();
@@ -56,7 +57,7 @@ const InputAccountName = ({
 
         if (regex.test(e.target.value)) {
           if (res.data.message === '이미 가입된 계정ID 입니다.') {
-            disabledButtonFunction(true);
+            // disabledButtonFunction(true);
             accountNameFunction('');
             setAlertID('* 이미 사용 중인 ID입니다.');
           } else {
@@ -83,13 +84,14 @@ const InputAccountName = ({
         type={inputType}
         id={id}
         placeholder={placeholder}
-        value={inputValue}
+        // value={inputValue}
         onChange={handleChange}
         ref={inputRef}
         isShowAlert={isShowAlert}
         autoComplete='off'
         spellCheck='false'
         maxLength={maxLength}
+        defaultValue={accountName}
       />
       <InputAlert>{alertPattern}</InputAlert>
       <InputAlert>{alertID}</InputAlert>

--- a/src/pages/ProfileSettingsPage/InputIntro.jsx
+++ b/src/pages/ProfileSettingsPage/InputIntro.jsx
@@ -6,8 +6,8 @@ import styled from 'styled-components';
 // inputType : input 태그의 타입 (생략시 기본값: text)
 // id : input 태그의 아이디
 // placeholder : input 태그에 적용할 placeholder
-const InputIntro = ({ labelText = 'label', inputType = 'text', id, placeholder, maxLength, introFunction }) => {
-  const [inputValue, setInputValue] = useState('');
+const InputIntro = ({ labelText = 'label', inputType = 'text', id, placeholder, maxLength, introFunction, intro }) => {
+  const [inputValue, setInputValue] = useState(`${intro ? intro : ''}`);
 
   const [isShowAlert, setIsShowAlert] = useState(false);
   const inputRef = useRef();
@@ -31,13 +31,14 @@ const InputIntro = ({ labelText = 'label', inputType = 'text', id, placeholder, 
         type={inputType}
         id={id}
         placeholder={placeholder}
-        value={inputValue}
+        // value={inputValue}
         onChange={handleChange}
         ref={inputRef}
         isShowAlert={isShowAlert}
         autoComplete='off'
         spellCheck='false'
         maxLength={maxLength}
+        defaultValue={intro}
       />
     </InputWrapper>
   );

--- a/src/pages/ProfileSettingsPage/InputIntro.jsx
+++ b/src/pages/ProfileSettingsPage/InputIntro.jsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 // id : input 태그의 아이디
 // placeholder : input 태그에 적용할 placeholder
 const InputIntro = ({ labelText = 'label', inputType = 'text', id, placeholder, maxLength, introFunction, intro }) => {
-  const [inputValue, setInputValue] = useState(`${intro ? intro : ''}`);
+  const [inputValue, setInputValue] = useState('');
 
   const [isShowAlert, setIsShowAlert] = useState(false);
   const inputRef = useRef();

--- a/src/pages/ProfileSettingsPage/InputUserName.jsx
+++ b/src/pages/ProfileSettingsPage/InputUserName.jsx
@@ -16,7 +16,7 @@ const InputUserName = ({
   userNameFunction,
   userName,
 }) => {
-  const [inputValue, setInputValue] = useState(`${userName ? userName : ''}`);
+  const [inputValue, setInputValue] = useState('');
 
   const [isShowAlert, setIsShowAlert] = useState(false);
   const inputRef = useRef();

--- a/src/pages/ProfileSettingsPage/InputUserName.jsx
+++ b/src/pages/ProfileSettingsPage/InputUserName.jsx
@@ -14,8 +14,9 @@ const InputUserName = ({
   placeholder,
   maxLength,
   userNameFunction,
+  userName,
 }) => {
-  const [inputValue, setInputValue] = useState('');
+  const [inputValue, setInputValue] = useState(`${userName ? userName : ''}`);
 
   const [isShowAlert, setIsShowAlert] = useState(false);
   const inputRef = useRef();
@@ -43,13 +44,14 @@ const InputUserName = ({
         type={inputType}
         id={id}
         placeholder={placeholder}
-        value={inputValue}
+        // value={inputValue}
         onChange={handleChange}
         ref={inputRef}
         isShowAlert={isShowAlert}
         autoComplete='off'
         spellCheck='false'
         maxLength={maxLength}
+        defaultValue={userName}
       />
       {!(inputValue.length === 0) && inputValue.length < 2 && <InputAlert>{children}</InputAlert>}
     </InputWrapper>

--- a/src/pages/ProfileSettingsPage/ProfileInfo.jsx
+++ b/src/pages/ProfileSettingsPage/ProfileInfo.jsx
@@ -12,7 +12,11 @@ const ProfileInfo = ({
   accountNameFunction,
   introFunction,
   imageFunction,
-  disabledButtonFunction,
+  // disabledButtonFunction,
+
+  userName,
+  accountName,
+  intro,
 }) => {
   // 업로드 이미지 섬네일
   const [thumbnailImg, setThumbnailImg] = useState('');
@@ -61,6 +65,7 @@ const ProfileInfo = ({
           maxLength='10'
           children={'* 2~10자 이내여야 합니다.'}
           userNameFunction={userNameFunction}
+          userName={userName}
         />
         <InputAccountName
           labelText='계정 ID'
@@ -69,7 +74,8 @@ const ProfileInfo = ({
           placeholder='영문, 숫자, 특수문자(,), (_)만 사용 가능합니다.'
           maxLength='10'
           accountNameFunction={accountNameFunction}
-          disabledButtonFunction={disabledButtonFunction}
+          // disabledButtonFunction={disabledButtonFunction}
+          accountName={accountName}
         />
         <InputIntro
           labelText='소개'
@@ -78,6 +84,7 @@ const ProfileInfo = ({
           placeholder='자신과 판매할 상품에 대해 소개해 주세요.'
           maxLength='25'
           introFunction={introFunction}
+          intro={intro}
         ></InputIntro>
       </Form>
     </>

--- a/src/pages/ProfileSettingsPage/ProfileInfo.jsx
+++ b/src/pages/ProfileSettingsPage/ProfileInfo.jsx
@@ -17,6 +17,7 @@ const ProfileInfo = ({
   userName,
   accountName,
   intro,
+  image,
 }) => {
   // 업로드 이미지 섬네일
   const [thumbnailImg, setThumbnailImg] = useState('');
@@ -46,6 +47,8 @@ const ProfileInfo = ({
         <WrapperImg>
           {thumbnailImg ? (
             <ProfileImage src={thumbnailImg} alt='업로드 이미지' width='110' />
+          ) : image ? (
+            <ProfileImage src={image} alt='업로드 이미지' width='110' />
           ) : (
             <ProfileImage src={PROFILE1_IMAGE} alt='업로드 이미지' width='110' />
           )}

--- a/src/pages/ProfileSettingsPage/ProfileSettingsPage.jsx
+++ b/src/pages/ProfileSettingsPage/ProfileSettingsPage.jsx
@@ -7,7 +7,7 @@ import Button from '../../components/common/Button/Button';
 
 const ProfileSettingsPage = () => {
   const location = useLocation();
-  console.log(location.state);
+  // console.log(location.state);
 
   const email = location.state.email;
   const password = location.state.password;

--- a/src/pages/ProfileSettingsPage/ProfileSettingsPage.jsx
+++ b/src/pages/ProfileSettingsPage/ProfileSettingsPage.jsx
@@ -7,7 +7,7 @@ import Button from '../../components/common/Button/Button';
 
 const ProfileSettingsPage = () => {
   const location = useLocation();
-  // console.log(location.state);
+  console.log(location.state);
 
   const email = location.state.email;
   const password = location.state.password;
@@ -55,9 +55,9 @@ const ProfileSettingsPage = () => {
   // console.log(image);
 
   const [disabledButton, setDisabledButton] = useState(true);
-  const disabledButtonFunction = (value) => {
-    setDisabledButton(value);
-  };
+  // const disabledButtonFunction = (value) => {
+  //   setDisabledButton(value);
+  // };
 
   // 버튼 활성화
   useEffect(() => {
@@ -105,7 +105,7 @@ const ProfileSettingsPage = () => {
         accountNameFunction={accountNameFunction}
         introFunction={introFunction}
         imageFunction={imageFunction}
-        disabledButtonFunction={disabledButtonFunction}
+        // disabledButtonFunction={disabledButtonFunction}
       />
       <Link to='/'>
         <Button disabled={disabledButton} onClickHandler={onClickStartButtonHandler} size='L'>


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 프로필 정보를 불러오기 위한 통신 기능 추가 및 props 추가
- 페이지 이동 기능 추가
- image 미리보기 기능 추가
- 버튼 상태관리 추가


## 기대 결과
-  프로필 수정을 할 수 있습니다.


## 스크린샷
![ProfileModificationPage](https://user-images.githubusercontent.com/112460383/208929931-d9020325-d53b-4678-a708-12eb6e4c0f8a.gif)



## 리뷰어에게 전달 사항
- 버그가 수정되어 업데이트될 예정입니다. 
- 현재 아래와 같이 계정 ID의 입력값을 바꿨다가 다시 기존 계정 ID로 돌아가면 사용 중인 ID로 인지하는 버그가 있습니다.
- #261
![ProfileModificationPageBug](https://user-images.githubusercontent.com/112460383/208929263-3927c31c-cc4a-4e81-ac33-0a38e8dca2ab.gif)

- 추가 버그 발견 시 제보 부탁드립니다!




## 관련 이슈 번호
close : #253 
