### PR TITLE
fix: 회원가입 시 이미지 미적용에 따른 기본 프로필 이미지로 대체되는 현상 수정 (#266)

### DIFF
--- a/src/pages/ProfileSettingsPage/ProfileSettingsPage.jsx
+++ b/src/pages/ProfileSettingsPage/ProfileSettingsPage.jsx
@@ -4,6 +4,7 @@ import { Link, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import ProfileInfo from './ProfileInfo';
 import Button from '../../components/common/Button/Button';
+import { PROFILE1_IMAGE } from '../../styles/CommonImages';
 
 const ProfileSettingsPage = () => {
   const location = useLocation();
@@ -52,7 +53,10 @@ const ProfileSettingsPage = () => {
   const imageFunction = (value) => {
     setImage(value);
   };
-  // console.log(image);
+
+  if (!image) {
+    setImage(PROFILE1_IMAGE);
+  }
 
   const [disabledButton, setDisabledButton] = useState(true);
   // const disabledButtonFunction = (value) => {


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- #266 
- 위 현상을 수정하기 위해서 작업했습니다.


## 기대 결과
- 버그가 개선되었습니다.


## 리뷰어에게 전달 사항
- 없습니다.




## 관련 이슈 번호
close : #266 
