### PR TITLE
fix: 프로필페이지에서 follower 진입시 notFound뜨는 에러 해결 (#265)

### DIFF
--- a/src/pages/profilePage/ProfileHeader/ProfileHeader.jsx
+++ b/src/pages/profilePage/ProfileHeader/ProfileHeader.jsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
-// import AuthContextStore from '../../../context/AuthContext';
+import { AuthContextStore } from '../../../context/AuthContext';
 import UserProfileBtns from './UserProfileBtns';
 import MyProfileBtns from './MyProfileBtns';
 import ProfileImage from '../../../components/common/ProfileImage/ProfileImage';
-import { Link, useNavigate, useParams, useLocation } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import Loading from '../../../components/common/Loading/Loading';
 
 // followState : 버튼에 넘겨주기 위한 props => 팔로우 했을 경우 언팔 뜨게
@@ -12,7 +12,25 @@ import Loading from '../../../components/common/Loading/Loading';
 
 const ProfileHeader = ({ followState, profileData }) => {
   const location = useLocation();
+  const navigate = useNavigate();
   let { accountname } = useParams();
+  const { userAccountname } = useContext(AuthContextStore);
+
+  const onClickFollower = () => {
+    if (location.pathname === `/profile`) {
+      navigate(`/follow/${userAccountname}/follower`);
+    } else {
+      navigate(`/follow/${accountname}/follower`);
+    }
+  };
+
+  const onClickFollowing = () => {
+    if (location.pathname === `/profile`) {
+      navigate(`/follow/${userAccountname}/following`);
+    } else {
+      navigate(`/follow/${accountname}/following`);
+    }
+  };
 
   if (!profileData) {
     <Loading />;
@@ -21,7 +39,7 @@ const ProfileHeader = ({ followState, profileData }) => {
       <>
         <ProfileWrapper>
           <h2 className='sr-only'>프로필 정보</h2>
-          <Followers to={`/follow/${accountname}/follower`}>
+          <Followers onClick={onClickFollower}>
             <strong>{profileData.followerCount}</strong>
             <span>followers</span>
           </Followers>
@@ -30,7 +48,7 @@ const ProfileHeader = ({ followState, profileData }) => {
           <UserName>{profileData.username}</UserName>
           <UserID>@ {profileData.accountname}</UserID>
           <UserIntro>{profileData.intro}</UserIntro>
-          <Followings to={`/follow/${accountname}/following`}>
+          <Followings onClick={onClickFollowing}>
             <strong>{profileData.followingCount}</strong>
             <span>followings</span>
           </Followings>
@@ -71,7 +89,7 @@ const UserIntro = styled.span`
   color: var(--sub-text-color);
 `;
 
-const Followers = styled(Link)`
+const Followers = styled.button`
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/pages/profilePage/ProfileHeader/ProfileHeader.jsx
+++ b/src/pages/profilePage/ProfileHeader/ProfileHeader.jsx
@@ -16,19 +16,11 @@ const ProfileHeader = ({ followState, profileData }) => {
   let { accountname } = useParams();
   const { userAccountname } = useContext(AuthContextStore);
 
-  const onClickFollower = () => {
+  const onClickFollow = (followType) => {
     if (location.pathname === `/profile`) {
-      navigate(`/follow/${userAccountname}/follower`);
+      navigate(`/follow/${userAccountname}/${followType}`);
     } else {
-      navigate(`/follow/${accountname}/follower`);
-    }
-  };
-
-  const onClickFollowing = () => {
-    if (location.pathname === `/profile`) {
-      navigate(`/follow/${userAccountname}/following`);
-    } else {
-      navigate(`/follow/${accountname}/following`);
+      navigate(`/follow/${accountname}/${followType}`);
     }
   };
 
@@ -39,7 +31,7 @@ const ProfileHeader = ({ followState, profileData }) => {
       <>
         <ProfileWrapper>
           <h2 className='sr-only'>프로필 정보</h2>
-          <Followers onClick={onClickFollower}>
+          <Followers onClick={() => onClickFollow('follower')}>
             <strong>{profileData.followerCount}</strong>
             <span>followers</span>
           </Followers>
@@ -48,7 +40,7 @@ const ProfileHeader = ({ followState, profileData }) => {
           <UserName>{profileData.username}</UserName>
           <UserID>@ {profileData.accountname}</UserID>
           <UserIntro>{profileData.intro}</UserIntro>
-          <Followings onClick={onClickFollowing}>
+          <Followings onClick={() => onClickFollow('following')}>
             <strong>{profileData.followingCount}</strong>
             <span>followings</span>
           </Followings>


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 내 프로필 페이지에서 follower/following 버튼 클릭하면 notFound가 뜨는 현상을 해결했습니다. 승연님이 알려주신 방법대로 해결!


## 기대 결과
- 눌러도 팔로우/팔로잉 리스트 잘 나옵니다


## 리뷰어에게 전달 사항
_- 똑같은 코드에 follower/following 만 바뀌는거라 하나로 묶고 전달해주는 방법을 쓰고 싶었는데, 뭔가 문법오류(?)가 있는건지 잘 전달이 안돼서 그냥 두개로 나눴습니다. ㅠㅠ 이 부분 리팩토링시 깔끔하게 수정하려고 합니다!_
=> 이 부분 알려주셔서 개선했습니다. 속시원...


## 관련 이슈 번호
close : #265
