### PR TITLE
fix: 프로필 이미지가 꽉 차지 않는 현상 해결을 위해 object-fit: cover로 변경 (#276)

### DIFF
--- a/src/components/common/ProfileImage/ProfileImage.jsx
+++ b/src/components/common/ProfileImage/ProfileImage.jsx
@@ -25,6 +25,5 @@ const Image = styled.img`
   border: ${(props) => props.borderWeight}px solid var(--profile-border-color);
   border-radius: 50%;
   cursor: ${(props) => (props.isPointer ? 'pointer' : 'default')};
-  // IE 미지원
-  object-fit: scale-down;
+  object-fit: cover;
 `;


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 프로필 이미지가 꽉 차지 않는 현상 해결


## 기대 결과
- 프로필 이미지가 꽉 차게 보여집니다


## 스크린샷
<img width="372" alt="스크린샷 2022-12-22 오후 5 46 19" src="https://user-images.githubusercontent.com/105365737/209094674-79647d91-739f-429d-b8ec-820dc21e7455.png">



## 관련 이슈 번호
close : #276
