### PR TITLE
style :프로필페이지 게시물/상품 없을때의 화면 수정 (#282)

### DIFF
--- a/src/pages/profilePage/ProfileHeader/ProfileHeader.jsx
+++ b/src/pages/profilePage/ProfileHeader/ProfileHeader.jsx
@@ -27,7 +27,6 @@ const ProfileHeader = ({ profileData }) => {
   if (!profileData) {
     <Loading />;
   } else {
-    console.log(profileData);
     return (
       <>
         <ProfileWrapper>

--- a/src/pages/profilePage/ProfilePost/ProfilePost.jsx
+++ b/src/pages/profilePage/ProfilePost/ProfilePost.jsx
@@ -76,7 +76,7 @@ const ProfilePost = () => {
             <strong className='sr-only'>앨범으로 보기</strong>
           </AlbumIcon>
         </PostHeader>
-        {myPostList ? (
+        {myPostList.length > 0 ? (
           listBtn === true ? (
             <PostUl>
               <h3 className='sr-only'>리스트형 포스트 목록</h3>

--- a/src/pages/profilePage/ProfileProduct/ProfileProduct.jsx
+++ b/src/pages/profilePage/ProfileProduct/ProfileProduct.jsx
@@ -41,11 +41,16 @@ const ProfileProduct = () => {
   if (!isRendered) {
     <Loading />;
   } else {
-    return (
-      <ProductWrapper>
-        <h2>판매 중인 상품</h2>
-        <MultiItemCarousel itemList={productList} />
-      </ProductWrapper>
+    return productList.length > 0 ? (
+      <>
+        <ProductWrapper>
+          <h2>판매 중인 상품</h2>
+          <MultiItemCarousel itemList={productList} />
+        </ProductWrapper>
+        <SectionBorder />
+      </>
+    ) : (
+      <></>
     );
   }
 };
@@ -60,4 +65,12 @@ const ProductWrapper = styled.section`
     font-size: 1.6em;
     font-weight: 700;
   }
+`;
+
+const SectionBorder = styled.div`
+  height: 6px;
+  width: 100%;
+  border-top: 0.5px solid var(--border-color);
+  border-bottom: 0.5px solid var(--border-color);
+  background-color: var(--chat-bg-color);
 `;


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 프로필페이지에서 게시물이나 판매중인 상품이 없을때의 화면을 재구성하였고, 뜨지 않는 현상을 수정했습니다


## 기대 결과

<img width="385" alt="image" src="https://user-images.githubusercontent.com/96304623/209300218-9f29b40a-8de1-4dea-8e4c-5ccee48a7be8.png">

## 관련 이슈 번호
close : #282 
