### PR TITLE
feat: props로 closeAlert을 전달받지 않은 경우 closeAlert 버튼이 출력되지 않도록 수정 (#298)

### DIFF
--- a/src/components/common/modal/Alert.jsx
+++ b/src/components/common/modal/Alert.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const Alert = ({ summary, title, trigger, closeAlert, tiggerFunc }) => {
+const Alert = ({ summary, title, trigger, closeAlert = '', tiggerFunc }) => {
   return (
     <Section>
       <h2 className='sr-only'>{summary}</h2>
@@ -9,7 +9,7 @@ const Alert = ({ summary, title, trigger, closeAlert, tiggerFunc }) => {
       <ContentsWrapper>
         <Title>{title}</Title>
         <ButtonWrapper>
-          <button onClick={closeAlert}>취소</button>
+          {closeAlert ? <button onClick={closeAlert}>취소</button> : <></>}
           <button onClick={tiggerFunc}>{trigger}</button>
         </ButtonWrapper>
       </ContentsWrapper>


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 기존 ) 트리거 버튼이 두 개인 경우만 사용 가능 (취소/수정, 취소/삭제, 취소/신고 등)
- 수정 후 ) 트리거 버튼이 한 개인 경우도 사용 가능 (확인 등)


## 기대 결과
- 트리거 버튼이 한 개인 경우에도 Alert 컴포넌트를 사용할 수 있습니다.


## 리뷰어에게 전달 사항
- 트리거 버튼이 한 개인 경우에는 props로 closeAlert을 전달하지 않으면 됩니다.
- 트리거 버튼이 한개인 경우 적용 예시 )
```jsx
        <Alert
          summary={is신고성공여부 ? '게시글 신고 완료 알림창' : '게시글 신고 실패 알림창'}
          title={is신고성공여부 ? '게시글이 신고되었습니다.' : '게시글 신고에 실패하였습니다.'}
          trigger={'확인'}
          tiggerFunc={clearReportPost}
        />
```

## 스크린샷
![스크린샷 2022-12-26 오후 12 45 52](https://user-images.githubusercontent.com/105365737/209497233-0e441be2-e0b9-4ef2-bea8-91c9026129f7.png)
- 기존 ) 트리거 버튼이 두개인 경우에만 사용 가능했음

![스크린샷 2022-12-26 오후 12 46 00](https://user-images.githubusercontent.com/105365737/209497248-3fcadf47-160f-46b8-a3b0-e574aa89f15c.png)
- 수정 후 ) 위와 같은 경우도 사용 가능

## 관련 이슈 번호
close : #298 
