### PR TITLE
fix: useLocation 커스텀 훅을 useCurrentLocation으로 변경 (#302)

### DIFF
--- a/src/hooks/useCurrentLocation.jsx
+++ b/src/hooks/useCurrentLocation.jsx
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { useContext, useEffect } from 'react';
 import { UserLocationContextStore } from '../context/UserLocationContext';
 
-const useLocation = ({ isLocationUpdate, setIsLocationUpdate }) => {
+const useCurrentLocation = ({ isLocationUpdate, setIsLocationUpdate }) => {
   const { setLongitude, setLatitude, setDistrict, longitude, latitude } = useContext(UserLocationContextStore);
   const KAKAOMAP_API = process.env.REACT_APP_KAKAOMAP_API;
 
@@ -44,4 +44,4 @@ const useLocation = ({ isLocationUpdate, setIsLocationUpdate }) => {
   }, [longitude, latitude]);
 };
 
-export default useLocation;
+export default useCurrentLocation;

--- a/src/pages/communityPage/CommunityWeatherPage/CommunityWeatherPage.jsx
+++ b/src/pages/communityPage/CommunityWeatherPage/CommunityWeatherPage.jsx
@@ -2,7 +2,7 @@ import axios from 'axios';
 import React, { useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { UserLocationContextStore } from '../../../context/UserLocationContext';
-import useLocation from '../../../hooks/useLocation';
+import useCurrentLocation from '../../../hooks/useCurrentLocation';
 import WeatherDescription from '../../../utils/WeatherDescription';
 import CommunityLayout from '../CommunityLayout';
 import DetailWeatherInfo from './DetailWeatherInfo';
@@ -19,7 +19,7 @@ const CommunityWeatherPage = () => {
   const [isLocationUpdate, setIsLocationUpdate] = useState(true);
   const [walkingScore, setWalkingScore] = useState(0);
 
-  const checkUserLocation = useLocation({ isLocationUpdate, setIsLocationUpdate });
+  const checkUserLocation = useCurrentLocation({ isLocationUpdate, setIsLocationUpdate });
 
   useEffect(() => {
     const getDate = () => {

--- a/src/pages/communityPage/communityHospitalPage/CommunityHospitalMainPage/CommunityHospitaMainlPage.jsx
+++ b/src/pages/communityPage/communityHospitalPage/CommunityHospitalMainPage/CommunityHospitaMainlPage.jsx
@@ -5,7 +5,7 @@ import { BOTTOM_ARROW_ICON } from '../../../../styles/CommonIcons';
 import HospitalList from './HospitalList';
 import CurrentLocationBar from '../CurrentLocationBar';
 import FilterMenu from './FilterMenu';
-import useLocation from '../../../../hooks/useLocation';
+import useCurrentLocation from '../../../../hooks/useCurrentLocation';
 
 const CommunityHospitaMainlPage = () => {
   const [isShowFilterMenu, setIsShowFilterMenu] = useState(false);
@@ -18,7 +18,7 @@ const CommunityHospitaMainlPage = () => {
   ];
 
   const [isLocationUpdate, setIsLocationUpdate] = useState(true);
-  const checkUserLocation = useLocation({ isLocationUpdate, setIsLocationUpdate });
+  const checkUserLocation = useCurrentLocation({ isLocationUpdate, setIsLocationUpdate });
 
   const onClickBackgroundHandler = () => {
     setIsShowFilterMenu(!isShowFilterMenu);


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- react-router-dom Hook과 custom Hook의 이름이 `useLocation`으로 동일하여 에러 발생


## 기대 결과
- useLocation 훅 사용시 에러가 발생하지 않습니다


## 관련 이슈 번호
close : #302 
