### PR TITLE
feat: 프로필페이지 채팅 이동 및 카카오톡 공유하기 기능 추가 (#294)

### DIFF
--- a/src/pages/profilePage/ProfileHeader/UserProfileBtns.jsx
+++ b/src/pages/profilePage/ProfileHeader/UserProfileBtns.jsx
@@ -26,10 +26,11 @@ const UserProfileBtns = ({ profileData }) => {
   });
 
   const shareToKakaotalk = () => {
+    const KAKAO_SHARE_API = process.env.REACT_APP_KAKAO_SHARE_API;
     if (window.Kakao) {
       const kakao = window.Kakao;
       if (!kakao.isInitialized()) {
-        kakao.init('e2720c89d4c69853e40e7494239554f2');
+        kakao.init(KAKAO_SHARE_API);
       }
       kakao.Link.sendDefault({
         objectType: 'feed',

--- a/src/pages/profilePage/ProfileHeader/UserProfileBtns.jsx
+++ b/src/pages/profilePage/ProfileHeader/UserProfileBtns.jsx
@@ -1,20 +1,48 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import axios from 'axios';
+import styled from 'styled-components';
 import { useState, useContext } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import styled from 'styled-components';
-import axios from 'axios';
+import { AuthContextStore } from '../../../context/AuthContext';
+
 import Button from '../../../components/common/Button/Button';
 import { CHAT_ICON, SHARE_ICON } from '../../../styles/CommonIcons';
-import { AuthContextStore } from '../../../context/AuthContext';
 
 const UserProfileBtns = ({ profileData }) => {
   const [isFollowing, setIsFollowing] = useState(profileData.isfollow);
   const { userToken } = useContext(AuthContextStore);
   const { accountname } = useParams();
   const navigate = useNavigate();
-  
   const handleGoChat = () => {
     navigate(`/chat/${accountname}`);
+  };
+
+  useEffect(() => {
+    const script = document.createElement('script');
+    script.src = 'https://developers.kakao.com/sdk/js/kakao.js';
+    script.async = true;
+    document.body.appendChild(script);
+    return () => document.body.removeChild(script);
+  });
+
+  const shareToKakaotalk = () => {
+    if (window.Kakao) {
+      const kakao = window.Kakao;
+      if (!kakao.isInitialized()) {
+        kakao.init('e2720c89d4c69853e40e7494239554f2');
+      }
+      kakao.Link.sendDefault({
+        objectType: 'feed',
+        content: {
+          title: '가져도댕냥',
+          description: '우리집 댕냥이를 위한 따뜻한 선물',
+          imageUrl: '',
+          link: {
+            webUrl: 'http://localhost:3000/',
+          },
+        },
+      });
+    }
   };
 
   const handleFollow = async () => {
@@ -45,7 +73,7 @@ const UserProfileBtns = ({ profileData }) => {
       >
         {isFollowing ? '언팔로우' : '팔로우'}
       </Button>
-      <ShareBtn />
+      <ShareBtn onClick={shareToKakaotalk} />
     </UserProfileBtnsStyle>
   );
 };

--- a/src/pages/profilePage/ProfileHeader/UserProfileBtns.jsx
+++ b/src/pages/profilePage/ProfileHeader/UserProfileBtns.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useState, useContext } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import axios from 'axios';
 import Button from '../../../components/common/Button/Button';
@@ -11,6 +11,11 @@ const UserProfileBtns = ({ profileData }) => {
   const [isFollowing, setIsFollowing] = useState(profileData.isfollow);
   const { userToken } = useContext(AuthContextStore);
   const { accountname } = useParams();
+  const navigate = useNavigate();
+  
+  const handleGoChat = () => {
+    navigate(`/chat/${accountname}`);
+  };
 
   const handleFollow = async () => {
     const option = {
@@ -30,7 +35,7 @@ const UserProfileBtns = ({ profileData }) => {
 
   return (
     <UserProfileBtnsStyle>
-      <ProfileBtn />
+      <ChatBtn onClick={handleGoChat} />
       <Button
         size='M'
         onClickHandler={handleFollow}
@@ -40,7 +45,7 @@ const UserProfileBtns = ({ profileData }) => {
       >
         {isFollowing ? '언팔로우' : '팔로우'}
       </Button>
-      <ProfileBtn isShare={true} />
+      <ShareBtn />
     </UserProfileBtnsStyle>
   );
 };
@@ -56,9 +61,17 @@ const UserProfileBtnsStyle = styled.div`
   margin-bottom: 2.6em;
 `;
 
-const ProfileBtn = styled.button`
-  background: ${(props) =>
-    props.isShare ? `url(${SHARE_ICON}) no-repeat center / 15px` : `url(${CHAT_ICON}) no-repeat center / 15px`};
+const ShareBtn = styled.button`
+  background: url(${SHARE_ICON}) no-repeat center / 15px;
+  width: 34px;
+  height: 34px;
+  color: var(--sub-text-color);
+  border: 1px solid var(--border-color);
+  border-radius: 50%;
+`;
+
+const ChatBtn = styled.button`
+  background: url(${CHAT_ICON}) no-repeat center / 15px;
   width: 34px;
   height: 34px;
   color: var(--sub-text-color);


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 채팅방 이동하기/ 공유하기 기능을 추가했습니다. 


## 기대 결과
- 공유하기 버튼 누르면 카카오톡으로 공유가 가능합니다.


## 리뷰어에게 전달 사항
- 현재 localhost 3000번으로 주소는 임시 저장해놓은 상태입니다!
- API 불러오고나서 프로필 페이지가 급격히 느려진 것 같습니다....리팩토링할때 고려해봐야할 것 같습니다 ㅠㅠ



## 관련 이슈 번호
close : #294 
