### PR TITLE
fix: 게시물 이미지 파일이 존재하지 않을때도 빈 이미지 파일이 렌더되는 현상 수정 (#338)

### DIFF
--- a/src/components/common/Post/Post.jsx
+++ b/src/components/common/Post/Post.jsx
@@ -46,7 +46,6 @@ const Post = ({ post = {} }) => {
   const closeModal = () => {
     setIsOpenModal(false);
   };
-
   return (
     <>
       {data ? (
@@ -67,26 +66,31 @@ const Post = ({ post = {} }) => {
             <ContentWrapperDiv>
               <PostDetailLink to={`/post/${data.id}`} type='content'>
                 <ContentText>{data.content}</ContentText>
-                <SwiperWrapper>
-                  <Swiper
-                    spaceBetween={30}
-                    pagination={{
-                      clickable: true,
-                    }}
-                    modules={[Pagination]}
-                    className='mySwiper'
-                  >
-                    {imageFile ? (
-                      imageFile.map((img, i) => (
-                        <SwiperSlide key={i}>
-                          <ContentImg src={img} alt='' />
-                        </SwiperSlide>
-                      ))
-                    ) : (
-                      <></>
-                    )}
-                  </Swiper>
-                </SwiperWrapper>
+                {/* TODO : 이미지파일이 없으면 <></>대체한다. */}
+                {imageFile[0] !== '' ? (
+                  <SwiperWrapper>
+                    <Swiper
+                      spaceBetween={30}
+                      pagination={{
+                        clickable: true,
+                      }}
+                      modules={[Pagination]}
+                      className='mySwiper'
+                    >
+                      {imageFile ? (
+                        imageFile.map((img, i) => (
+                          <SwiperSlide key={i}>
+                            <ContentImg src={img} alt='' />
+                          </SwiperSlide>
+                        ))
+                      ) : (
+                        <></>
+                      )}
+                    </Swiper>
+                  </SwiperWrapper>
+                ) : (
+                  <></>
+                )}
               </PostDetailLink>
               <Div>
                 <LikeButton like={like} onClick={onClickLikeButtonHandler}>

--- a/src/components/common/Post/Post.jsx
+++ b/src/components/common/Post/Post.jsx
@@ -67,7 +67,7 @@ const Post = ({ post = {} }) => {
               <PostDetailLink to={`/post/${data.id}`} type='content'>
                 <ContentText>{data.content}</ContentText>
                 {/* TODO : 이미지파일이 없으면 <></>대체한다. */}
-                {imageFile[0] !== '' ? (
+                {imageFile[0] ? (
                   <SwiperWrapper>
                     <Swiper
                       spaceBetween={30}


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 게시물의 이미지가 존재하지 않을때도, 빈 이미지 파일이 렌더가 되어서 변경하였습니다.


## 기대 결과
- 게시물의 이미지가 존재할 경우에만, 렌더를 하도록 설정하였습니다.


## 리뷰어에게 전달 사항
- 확인부탁드려요~!


## 관련 이슈 번호
close : #338 
