### PR TITLE
refactor: 프로필페이지,상품,게시글  로딩컴포넌트 추가 (#342)

### DIFF
--- a/src/pages/profilePage/ProfileHeader/ProfileHeader.jsx
+++ b/src/pages/profilePage/ProfileHeader/ProfileHeader.jsx
@@ -57,10 +57,10 @@ const ProfileHeader = ({ profileData }) => {
 export default ProfileHeader;
 
 const LoadingWrapper = styled.div`
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 const ProfileWrapper = styled.header`

--- a/src/pages/profilePage/ProfilePage.jsx
+++ b/src/pages/profilePage/ProfilePage.jsx
@@ -18,8 +18,7 @@ const ProfilePage = () => {
   const navigate = useNavigate();
   // useParams() 사용해서 url 에 있는 파라미터 받아오기
   let { accountname } = useParams();
-  // state 랜더링 위해 추가
-  const [isRendered, setIsRendered] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   // 유저의 프로필 정보 담기
   const [userProfileInfo, setUserProfileInfo] = useState('');
@@ -45,46 +44,45 @@ const ProfilePage = () => {
       },
     })
       .then((res) => {
+        setIsLoading(false);
         setUserProfileInfo(res.data.profile);
       })
-      .catch((err) => console.error(err));
+      .catch((err) => {
+        setIsLoading(false);
+        console.error(err);
+      });
   };
 
   useEffect(() => {
-    setIsRendered(true);
     getUserProfileInfo();
   }, [userToken, accountname]);
 
-  if (!userProfileInfo) {
-    <LoadingWrapper>
-      <Loading />;
-    </LoadingWrapper>;
-  } else {
-    return (
-      <>
-        <TopBasicNav />
-        <ContentsLayout padding='2rem 0 0 0'>
-          <ProfileHeader profileData={userProfileInfo} />
-          <ProfileProduct />
-          <ProfilePost postState={true} />
-        </ContentsLayout>
-        <TabMenu currentMenuId={4} />
-      </>
-    );
-  }
+  return (
+    <>
+      {isLoading ? (
+        <LoadingWrapper>
+          <Loading />
+        </LoadingWrapper>
+      ) : (
+        <>
+          <TopBasicNav />
+          <ContentsLayout padding='2rem 0 0 0'>
+            <ProfileHeader profileData={userProfileInfo} />
+            <ProfileProduct />
+            <ProfilePost postState={true} />
+          </ContentsLayout>
+          <TabMenu currentMenuId={4} />
+        </>
+      )}
+    </>
+  );
 };
 
 export default ProfilePage;
+
 const LoadingWrapper = styled.div`
   position: fixed;
   top: 45%;
   left: 50%;
   transform: translate(-50%, -45%);
-`;
-const SectionBorder = styled.div`
-  height: 6px;
-  width: 100%;
-  border-top: 0.5px solid var(--border-color);
-  border-bottom: 0.5px solid var(--border-color);
-  background-color: var(--chat-bg-color);
 `;

--- a/src/pages/profilePage/ProfilePost/ProfilePost.jsx
+++ b/src/pages/profilePage/ProfilePost/ProfilePost.jsx
@@ -20,7 +20,7 @@ const ProfilePost = () => {
   const { userToken, userAccountname } = useContext(AuthContextStore);
   const [test, setTest] = useState([]);
   const location = useLocation();
-  const [isRendered, setIsRendered] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
   // 리스트형 앨범형 전환 버튼
   const [listBtn, setListBtn] = useState(true);
 
@@ -39,72 +39,77 @@ const ProfilePost = () => {
       },
     })
       .then((res) => {
+        setIsLoading(false);
         setMyPost(res.data.post);
       })
-      .catch((err) => console.log(err));
+      .catch((err) => {
+        setIsLoading(false);
+        console.log(err);
+      });
   };
 
   useEffect(() => {
-    setIsRendered(true);
     getMyPost();
   }, [userToken, accountname]);
 
-  useEffect(() => {
-    setTest(testFunction(myPostList));
-  }, [myPostList]);
+  // useEffect(() => {
+  //   setTest(testFunction(myPostList));
+  // }, [myPostList]);
 
-  if (!isRendered) {
-    <LoadingWrapper>
-      <Loading />
-    </LoadingWrapper>;
-  } else {
-    return (
-      <>
-        <h2 className='sr-only'>게시물 리스트</h2>
-        <PostHeader>
-          <ListIcon onClick={() => setListBtn(!listBtn)} show={listBtn}>
-            <strong className='sr-only'>리스트로 보기</strong>
-          </ListIcon>
-          <AlbumIcon onClick={() => setListBtn(!listBtn)} show={listBtn}>
-            <strong className='sr-only'>앨범으로 보기</strong>
-          </AlbumIcon>
-        </PostHeader>
-        {myPostList.length > 0 ? (
-          listBtn === true ? (
-            <PostUl>
-              <h3 className='sr-only'>리스트형 포스트 목록</h3>
-              {myPostList.map((post) => (
-                <Post key={post.id} post={post} />
-              ))}
-            </PostUl>
+  return (
+    <>
+      <PostHeader>
+        <ListIcon onClick={() => setListBtn(!listBtn)} show={listBtn}>
+          <strong className='sr-only'>리스트로 보기</strong>
+        </ListIcon>
+        <AlbumIcon onClick={() => setListBtn(!listBtn)} show={listBtn}>
+          <strong className='sr-only'>앨범으로 보기</strong>
+        </AlbumIcon>
+      </PostHeader>
+      {isLoading ? (
+        <LoadingWrapper>
+          <Loading />
+        </LoadingWrapper>
+      ) : (
+        <>
+          <h2 className='sr-only'>게시물 리스트</h2>
+          {myPostList.length > 0 ? (
+            listBtn === true ? (
+              <PostUl>
+                <h3 className='sr-only'>리스트형 포스트 목록</h3>
+                {myPostList.map((post) => (
+                  <Post key={post.id} post={post} />
+                ))}
+              </PostUl>
+            ) : (
+              <PostGrid>
+                <h3 className='sr-only'>앨범형 포스트 목록</h3>
+                {myPostList.map((post, i) => {
+                  return post.image ? (
+                    post.image.includes(',') ? (
+                      <li>
+                        <img key={post.id} src={post.image.split(',')[0]} alt='썸네일 이미지' />
+                        <img className='layer-icon' src={LAYERS_ICON} alt='레이어 아이콘' />
+                      </li>
+                    ) : (
+                      <>
+                        <img key={post.id} src={post.image} alt='썸네일 이미지'></img>
+                      </>
+                    )
+                  ) : null;
+                })}
+              </PostGrid>
+            )
           ) : (
-            <PostGrid>
-              <h3 className='sr-only'>앨범형 포스트 목록</h3>
-              {myPostList.map((post, i) => {
-                return post.image ? (
-                  post.image.includes(',') ? (
-                    <li>
-                      <img key={post.id} src={post.image.split(',')[0]} alt='썸네일 이미지' />
-                      <img className='layer-icon' src={LAYERS_ICON} alt='레이어 아이콘' />
-                    </li>
-                  ) : (
-                    <>
-                      <img key={post.id} src={post.image} alt='썸네일 이미지'></img>
-                    </>
-                  )
-                ) : null;
-              })}
-            </PostGrid>
-          )
-        ) : (
-          <NoPost>
-            <img src={EMPTY_POST_IMAGE} alt='포스트가 존재하지 않습니다' />
-            <span>아직 작성된 게시글이 없어요.</span>
-          </NoPost>
-        )}
-      </>
-    );
-  }
+            <NoPost>
+              <img src={EMPTY_POST_IMAGE} alt='포스트가 존재하지 않습니다' />
+              <span>아직 작성된 게시글이 없어요.</span>
+            </NoPost>
+          )}
+        </>
+      )}
+    </>
+  );
 };
 
 export default ProfilePost;
@@ -121,10 +126,11 @@ const testFunction = (myPostList) => {
 };
 
 const LoadingWrapper = styled.div`
-  position: fixed;
-  top: 45%;
-  left: 50%;
-  transform: translate(-50%, -45%);
+  margin-top: 30px;
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 const PostHeader = styled.section`

--- a/src/pages/profilePage/ProfileProduct/ProfileProduct.jsx
+++ b/src/pages/profilePage/ProfileProduct/ProfileProduct.jsx
@@ -12,7 +12,7 @@ const ProfileProduct = () => {
   const navigate = useNavigate();
   const { userToken, userAccountname } = useContext(AuthContextStore);
 
-  const [isRendered, setisRendered] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
   // 상품 담기
   const [productList, setProductList] = useState([]);
 
@@ -29,41 +29,47 @@ const ProfileProduct = () => {
       },
     })
       .then((res) => {
+        setIsLoading(false);
         setProductList(res.data.product);
       })
-      .catch((err) => console.error(err));
+      .catch((err) => {
+        setIsLoading(false);
+        console.error(err);
+      });
   };
   useEffect(() => {
-    setisRendered(true);
     getProduct();
   }, [userToken, accountname]);
 
-  if (!isRendered) {
-    <LoadingWrapper>
-      <Loading />;
-    </LoadingWrapper>;
-  } else {
-    return productList.length > 0 ? (
-      <>
-        <ProductWrapper>
-          <h2>판매 중인 상품</h2>
-          <MultiItemCarousel itemList={productList} />
-        </ProductWrapper>
-        <SectionBorder />
-      </>
-    ) : (
-      <></>
-    );
-  }
+  return (
+    <>
+      {isLoading ? (
+        <LoadingWrapper>
+          <Loading />
+        </LoadingWrapper>
+      ) : productList.length > 0 ? (
+        <>
+          <ProductWrapper>
+            <h2>판매 중인 상품</h2>
+            <MultiItemCarousel itemList={productList} />
+          </ProductWrapper>
+          <SectionBorder />
+        </>
+      ) : (
+        <></>
+      )}
+    </>
+  );
 };
 
 export default ProfileProduct;
 
 const LoadingWrapper = styled.div`
-  position: fixed;
-  top: 45%;
-  left: 50%;
-  transform: translate(-50%, -45%);
+  display: flex;
+  height: 208px;
+  flex: 1;
+  justify-content: center;
+  align-items: center;
 `;
 
 const ProductWrapper = styled.section`


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 프로필페이지, 상품, 게시글 컴포넌트에 로딩되는 동안 사용자에게 로딩 화면을 보여줄 수 있게 추가했습니다

## 기대 결과
![image](https://user-images.githubusercontent.com/96304623/209703407-dbeb9d91-3ea4-4c99-9750-3115f05e85db.png)

## 리뷰어에게 전달 사항
- 프로필 페이지, 상품 , 포스트 각각 3개에 로딩 컴포넌트를 추가했더니 너무많아서 징그러워 보이기도 합니다. 피드백 부탁드립니다 ㅠㅠ

## 관련 이슈 번호
close : #342 
