### PR TITLE
fix: Post 댓글버튼 클릭시 상세페이지로 이동하게 수정 (#350)

### DIFF
--- a/src/components/common/Post/Post.jsx
+++ b/src/components/common/Post/Post.jsx
@@ -97,7 +97,7 @@ const Post = ({ post = {} }) => {
                   <span className='sr-only'>{like ? '좋아요 취소' : '좋아요'}</span>
                 </LikeButton>
                 <LikeSpan>{data.heartCount}</LikeSpan>
-                <PostDetailLink to={`/data/${data.id}`} type='comment'>
+                <PostDetailLink to={`/post/${post.id}`} type='comment'>
                   <ChatImg src={REPLY_ICON} alt='댓글 보기' />
                   <ChatSpan>{data.commentCount}</ChatSpan>
                 </PostDetailLink>

--- a/src/pages/PostDetailPage/PostComment.jsx
+++ b/src/pages/PostDetailPage/PostComment.jsx
@@ -149,4 +149,5 @@ const MoreButton = styled.button`
 const ProfileImg = styled.img`
   width: 3.6rem;
   height: 3.6rem;
+  border-radius: 50%;
 `;


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 댓글버튼 클릭시 `/data/data.id 로 구현이 되어있어서 수정했습니다

## 기대 결과
- 이제 드디어 내 게시글의 댓글들을 볼 수 있습니다

## 리뷰어에게 전달
- 상세페이지에 현재 댓글 프로필 이미지가 네모 모양으로 나오는데, 해당 부분도 추가로 수정했습니다

<img width="455" alt="image" src="https://user-images.githubusercontent.com/96304623/209749860-cca07431-3257-41b5-acb0-6c194ee0ecf2.png">


## 관련 이슈 번호
close : #350 
