### PR TITLE
feat: react-intersection-observer 라이브러리로 피드 페이지 무한스크롤 기능 추가 (#354)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^16.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-intersection-observer": "^9.4.1",
         "react-router-dom": "^6.4.5",
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.6",
@@ -14340,6 +14341,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-intersection-observer": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.4.1.tgz",
+      "integrity": "sha512-IXpIsPe6BleFOEHKzKh5UjwRUaz/JYS0lT/HPsupWEQou2hDqjhLMStc5zyE3eQVT4Fk3FufM8Fw33qW1uyeiw==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -27417,6 +27426,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-intersection-observer": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.4.1.tgz",
+      "integrity": "sha512-IXpIsPe6BleFOEHKzKh5UjwRUaz/JYS0lT/HPsupWEQou2hDqjhLMStc5zyE3eQVT4Fk3FufM8Fw33qW1uyeiw==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dotenv": "^16.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-intersection-observer": "^9.4.1",
     "react-router-dom": "^6.4.5",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.6",

--- a/src/components/common/Post/Post.jsx
+++ b/src/components/common/Post/Post.jsx
@@ -29,7 +29,9 @@ const Post = ({ post = {} }) => {
   useEffect(() => {
     if (data) {
       setDateData(data.createdAt);
-      setImageFile(data.image.split(','));
+      if (data.image) {
+        setImageFile(data.image.split(','));
+      }
     }
   }, [data]);
 

--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -16,7 +16,7 @@ import Loading from '../../components/common/Loading/Loading';
 const FeedPage = () => {
   const navigate = useNavigate();
   const [isFollowingPost, setIsFollowingPost] = useState([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
 
   const url = 'https://mandarin.api.weniv.co.kr';
   const { userToken } = useContext(AuthContextStore);
@@ -30,8 +30,8 @@ const FeedPage = () => {
   const [loading, setLoading] = useState(false);
   const [ref, inView] = useInView();
 
+  // 서버에서 피드를 가져오는 함수
   const getUserFeed = useCallback(async () => {
-    setLoading(true);
     const option = {
       url: url + `/post/feed/?limit=${numFeed}`,
       method: 'GET',
@@ -40,12 +40,14 @@ const FeedPage = () => {
         'Content-type': 'application/json',
       },
     };
+    setLoading(true);
     await axios(option)
       .then((res) => {
         setIsLoading(false);
         setLoading(false);
         setIsFollowingPost(res.data.posts);
-        // console.log('useEffect 확인코드');
+        console.log(isFollowingPost);
+        console.log('useEffect 확인코드 axios');
       })
       .catch((err) => {
         setIsLoading(false);
@@ -53,10 +55,11 @@ const FeedPage = () => {
       });
   }, [numFeed]);
 
+  // getUserFeed 가 바뀔때마다 서버 요청하는 함수 실행
   useEffect(() => {
     if (userToken) {
       getUserFeed();
-      // console.log('useEffect 확인코드2');
+      console.log('useEffect 확인코드 getUserFeed ');
     } else {
       navigate('/');
       return;
@@ -64,11 +67,17 @@ const FeedPage = () => {
   }, [userToken, getUserFeed]);
 
   useEffect(() => {
+    // 사용자가 마지막 요소를 보고있고(inview === true), 로딩중이 아니라면
     if (inView && !loading) {
       setNumFeed((current) => current + 10);
-      // console.log('useEffect 확인코드3');
+      window.scrollTo({ top: 200, behavior: 'smooth' });
     }
   }, [inView, loading]);
+
+  // 진짜 마지막에 다다랐을때 실행해줄 코드를 추가해줄 예정.
+  // 방법을 고민해보자
+  //1. 마지막 게시글 아이디가 새로 불러온 요청의 마지막 게시글 아이디와 똑같다면 axios 호출 멈추기
+  //2. 어차피 스크롤 이벤트니까 띠용효과 주기 . 마지막으로 이동하면 스크롤이 위로 올라가게 => 일단 이렇게 구현함
 
   return (
     <>
@@ -83,6 +92,7 @@ const FeedPage = () => {
             <ContentsLayout>
               <div>
                 {isFollowingPost.map((post, i) =>
+                  // isFollowingPost의 마지막 요소라면 ref추가
                   isFollowingPost.length - 1 === i ? (
                     <div key={post.id} ref={ref} />
                   ) : (

--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -18,7 +18,6 @@ const FeedPage = () => {
   const [isFollowingPost, setIsFollowingPost] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
 
-  const url = 'https://mandarin.api.weniv.co.kr';
   const { userToken } = useContext(AuthContextStore);
 
   const goSearch = () => {
@@ -26,14 +25,16 @@ const FeedPage = () => {
   };
 
   // 무한 스크롤
-  const [numFeed, setNumFeed] = useState(10);
+  const [numFeed, setNumFeed] = useState(0);
   const [loading, setLoading] = useState(false);
+  const [done, setDone] = useState(false);
   const [ref, inView] = useInView();
 
   // 서버에서 피드를 가져오는 함수
   const getUserFeed = useCallback(async () => {
+    const url = 'https://mandarin.api.weniv.co.kr';
     const option = {
-      url: url + `/post/feed/?limit=${numFeed}`,
+      url: url + `/post/feed/?limit=10&skip=${numFeed}`,
       method: 'GET',
       headers: {
         Authorization: `Bearer ${userToken}`,
@@ -41,13 +42,16 @@ const FeedPage = () => {
       },
     };
     setLoading(true);
+
     await axios(option)
       .then((res) => {
-        setIsLoading(false);
+        // 기존의 데이터와 새로운 데이터 배열 합치기
+        setIsFollowingPost(isFollowingPost.concat(res.data.posts));
         setLoading(false);
-        setIsFollowingPost(res.data.posts);
-        console.log(isFollowingPost);
-        console.log('useEffect 확인코드 axios');
+        setIsLoading(false);
+        if (res.data.posts.length < 10) {
+          setDone(true);
+        }
       })
       .catch((err) => {
         setIsLoading(false);
@@ -55,29 +59,19 @@ const FeedPage = () => {
       });
   }, [numFeed]);
 
-  // getUserFeed 가 바뀔때마다 서버 요청하는 함수 실행
   useEffect(() => {
-    if (userToken) {
+    // 새로 받아온 데이터 배열 개수가 10개 미만일때 스크롤 멈추기
+    if (!done) {
       getUserFeed();
-      console.log('useEffect 확인코드 getUserFeed ');
-    } else {
-      navigate('/');
-      return;
     }
-  }, [userToken, getUserFeed]);
+  }, [numFeed]);
 
   useEffect(() => {
     // 사용자가 마지막 요소를 보고있고(inview === true), 로딩중이 아니라면
     if (inView && !loading) {
       setNumFeed((current) => current + 10);
-      window.scrollTo({ top: 200, behavior: 'smooth' });
     }
   }, [inView, loading]);
-
-  // 진짜 마지막에 다다랐을때 실행해줄 코드를 추가해줄 예정.
-  // 방법을 고민해보자
-  //1. 마지막 게시글 아이디가 새로 불러온 요청의 마지막 게시글 아이디와 똑같다면 axios 호출 멈추기
-  //2. 어차피 스크롤 이벤트니까 띠용효과 주기 . 마지막으로 이동하면 스크롤이 위로 올라가게 => 일단 이렇게 구현함
 
   return (
     <>

--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -82,14 +82,14 @@ const FeedPage = () => {
           {isFollowingPost.length > 0 ? (
             <ContentsLayout>
               <div>
-                {isFollowingPost.map((post,i) => 
-                  isFollowingPost.length -1 === i ? (
-                    <div ref={ref}/>
+                {isFollowingPost.map((post, i) =>
+                  isFollowingPost.length - 1 === i ? (
+                    <div key={post.id} ref={ref} />
                   ) : (
                     <div key={post.id}>
-                    <Post post={post} />
-                  </div>
-                  )
+                      <Post post={post} />
+                    </div>
+                  ),
                 )}
               </div>
             </ContentsLayout>

--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -26,7 +26,7 @@ const FeedPage = () => {
   };
 
   // 무한 스크롤
-  const [numFeed, setNumFeed] = useState(20);
+  const [numFeed, setNumFeed] = useState(10);
   const [loading, setLoading] = useState(false);
   const [ref, inView] = useInView();
 


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 버그리포트의 '피드 게시물이 최대 10개까지만 보이는 현상' 을 라이브러리를 설치하여 스크롤을 내리는 방법으로 해결하고자 했습니다.

## 기대 결과
- 피드게시물을 무한으로 내려볼 수 있습니다


## 리뷰어에게 전달 사항
-  머지 후 package.json에  "react-intersection-observer": "^9.4.1", 가 추가되었는지 확인 부탁드립니다
- `npm i ` 명령어로 모듈 설치 부탁드립니다 
- 참고자료 : https://devkkiri.com/post/927ae150-7627-4e25-b29f-2d0293b82332
- 에러가 발생하거나 버그를 보시면 바로 말씀 부탁드립니다. 
- 이전에 useEffect 이슈가 있어서 확인용 console.log()을 넣고 일단 주석처리 해둔 상태입니다. 리팩토링때 문제 없다면 지우겠습니다

## 관련 이슈 번호
close : #354 
