### PR TITLE
design: 버튼 컴포넌트에 isActive 옵션 추가 (#358)

### DIFF
--- a/src/components/common/Button/Button.jsx
+++ b/src/components/common/Button/Button.jsx
@@ -9,6 +9,7 @@ const Button = ({
   borderColor = 'transparent',
   textColor = 'var(--main-bg-color)',
   onClickHandler,
+  isActive = true,
 }) => {
   return (
     <StyledButton
@@ -18,6 +19,7 @@ const Button = ({
       borderColor={borderColor}
       textColor={textColor}
       onClick={onClickHandler}
+      isActive={isActive}
     >
       {children}
     </StyledButton>
@@ -74,11 +76,15 @@ const sizeStyles = css`
           font-weight: 400;
           width: 5.6rem;
           border-radius: 2.6rem;
-          &:active {
-            border: 1px solid var(--border-color);
-            background: var(--main-bg-color);
-            color: var(--sub-text-color);
-          }
+          ${(props) =>
+            props.isActive &&
+            css`
+              &:active {
+                border: 1px solid var(--border-color);
+                background: var(--main-bg-color);
+                color: var(--sub-text-color);
+              }
+            `}
         `;
       default:
         return;

--- a/src/components/common/userItem/Follow/Follow.jsx
+++ b/src/components/common/userItem/Follow/Follow.jsx
@@ -42,6 +42,7 @@ const Follow = ({ followUserInfo }) => {
           borderColor={isFollow ? 'var(--border-color)' : undefined}
           textColor={isFollow ? 'var(--sub-text-color)' : undefined}
           onClickHandler={switchFollow}
+          isActive={false}
         >
           {isFollow ? '취소' : '팔로우'}
         </Button>


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 팔로우 페이지에서 버튼이 깜빡이는 현상을 수정하기 위해 active 스타일 온/오프를 위해 isActive 옵션을 추가했습니다.
- 기본값을 true로 설정해둬서 이미 만들어진 버튼은 수정할 필요가 없습니다.


## 기대 결과
- isActive=false 옵션을 주면 active 효과가 적용되지 않습니다.
- 팔로우 페이지에서 버튼 깜빡이는 현상이 사라집니다.


## 리뷰어에게 전달 사항
- [Styled Components: props for hover](https://stackoverflow.com/questions/47635991/styled-components-props-for-hover)를 참고해서 수정했습니다.


## 관련 이슈 번호
close : #358 
