### PR TITLE
refactor: 이미지 리사이징을 위한 코드 추가 및 이미지 스타일 속성 변경을 위한 코드 수정 (#352)

### DIFF
--- a/src/pages/ProductRegistrationPage/ProductRegistrationPage.jsx
+++ b/src/pages/ProductRegistrationPage/ProductRegistrationPage.jsx
@@ -233,7 +233,7 @@ const Label = styled.label`
 
 // IE 미지원
 const Img = styled.img`
-  object-fit: scale-down;
+  object-fit: cover;
 `;
 
 const Form = styled.form`


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 이미지 리사이징을 위한 ProductRegistrationPage.jsx 리팩토링을 진행했습니다.
- 이미지 스타일 속성을 기존 프로필 이미지 속성과 동일하게 ``object-fit: scale-down;`` 에서 ``object-fit: cover;`` 로 변경 했습니다.


## 기대 결과
- 이미지 리사이징 코드가 추가 되어 비교적 용량이 큰 이미지도 업로드가 가능합니다.
- 이미지가 종횡비를 유지하면서 정의된 너비와 높이를 가득 채울때까지 확대됩니다.


## 리뷰어에게 전달 사항
- 아래와 같이 옵션 값을 부여할 수 있습니다.
```jsx
maxSizeMB: number,
maxWidthOrHeight: number,
```
- 머지 이후에 평소에 업로드가 잘되지 않았던 파일로 확인해 보시고 피드백 부탁드립니다!


## 스크린샷
> ![image](https://user-images.githubusercontent.com/112460383/209811256-f06e65f3-8aab-40ef-98f9-2dc20b194df9.png)

**위와 같이 102400B (100KB)로 제한이 되어있으므로, 업로드가 되지 않습니다.**

> ``리사이징 이전 이미지 파일 크기`` 
![image](https://user-images.githubusercontent.com/112460383/209813249-71d18e3b-dcf0-4260-8835-cf347ce1292a.png)

> ``리사이징 이후 이미지 파일 크기`` 
![image](https://user-images.githubusercontent.com/112460383/209813693-c49f25bc-cde7-46d5-a8e8-7eac21100d03.png)

**기존 이미지 크기의 1% 수준으로 크기가 줄어들었습니다.**

## 관련 이슈 번호
close : #352 
