### PR TITLE
fix: 상품명 길이 제한 수정 (#363)

### DIFF
--- a/src/pages/ProductRegistrationPage/ItemNameInput.jsx
+++ b/src/pages/ProductRegistrationPage/ItemNameInput.jsx
@@ -38,13 +38,13 @@ const ItemNameInput = ({
     }
 
     if (itemNameModFunction) {
-      if (e.target.value.length >= 2 && e.target.value.length <= 10) {
+      if (e.target.value.length >= 2 && e.target.value.length <= 15) {
         itemNameModFunction(e.target.value);
       } else {
         itemNameModFunction('');
       }
     } else {
-      if (e.target.value.length >= 2 && e.target.value.length <= 10) {
+      if (e.target.value.length >= 2 && e.target.value.length <= 15) {
         itemNameFunction(e.target.value);
       } else {
         itemNameFunction('');


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 명세에 따라 2-15자 이내로 상품명을 입력해야 합니다. 하지만 현재 제가 작성한 코드는 2-10자 이내로 입력해야 버튼이 활성화 되고, 11~15자를 입력하면 버튼 활성화가 풀리는 상황이었기 때문에 수정했습니다.


## 기대 결과
- 올바른 길이의 상품명을 입력하고 기능이 정상 작동합니다.



## 관련 이슈 번호
close : #363 
