### PR TITLE
fix: 프로필페이지 피드 게시글이 없을 때 세로로 긴 화면에서 공간이 남아 보이는 현상 해결 (#367)

### DIFF
--- a/src/components/layout/ContentsLayout/ContentsLayout.jsx
+++ b/src/components/layout/ContentsLayout/ContentsLayout.jsx
@@ -6,9 +6,9 @@ import styled from 'styled-components';
 // * 사용법 - 2가지 props를 전달해줘야 합니다 *
 // isTabMenu : 탭 메뉴 존재 여부를 boolean 값으로 전달해야 합니다. true인 경우 margin-bottom: 6rem이 적용됩니다. 기본값은 true입니다.
 // padding : 적용할 패딩을 문자열 값으로 전달해야 합니다. 이때 단축 속성으로 전달해야 합니다. 기본값은 상단 2rem, 좌우 1.6rem으로 적용되어 있습니다.
-const ContentsLayout = ({ children, isTabMenu = true, padding = '2rem 1.6rem 0 1.6rem' }) => {
+const ContentsLayout = ({ children, isTabMenu = true, padding = '2rem 1.6rem 0 1.6rem', isFill = false }) => {
   return (
-    <ContentsWrapper isTabMenu={isTabMenu} padding={padding}>
+    <ContentsWrapper isTabMenu={isTabMenu} padding={padding} isFill={isFill}>
       {children}
     </ContentsWrapper>
   );
@@ -17,6 +17,9 @@ const ContentsLayout = ({ children, isTabMenu = true, padding = '2rem 1.6rem 0 1
 export default ContentsLayout;
 
 const ContentsWrapper = styled.main`
+  display: flex;
+  flex-direction: column;
+  ${(props) => (props.isFill ? 'height: calc(100vh - 110px);' : '')};
   margin-top: 4.8rem;
   margin-bottom: ${(props) => (props.isTabMenu ? '6rem' : 0)};
   padding: ${(props) => props.padding};

--- a/src/pages/profilePage/ProfilePage.jsx
+++ b/src/pages/profilePage/ProfilePage.jsx
@@ -19,6 +19,7 @@ const ProfilePage = () => {
   // useParams() 사용해서 url 에 있는 파라미터 받아오기
   let { accountname } = useParams();
   const [isLoading, setIsLoading] = useState(true);
+  const [emptyPost, setEmptyPost] = useState(false);
 
   // 유저의 프로필 정보 담기
   const [userProfileInfo, setUserProfileInfo] = useState('');
@@ -51,7 +52,7 @@ const ProfilePage = () => {
         .catch((err) => {
           setIsLoading(false);
           console.error(err);
-      });
+        });
     };
     getUserProfileInfo();
   }, [url, accountname, userAccountname, userToken]);
@@ -65,10 +66,10 @@ const ProfilePage = () => {
       ) : (
         <>
           <TopBasicNav />
-          <ContentsLayout padding='2rem 0 0 0'>
+          <ContentsLayout padding='2rem 0 0 0' isFill={emptyPost}>
             <ProfileHeader profileData={userProfileInfo} />
             <ProfileProduct />
-            <ProfilePost postState={true} />
+            <ProfilePost setEmptyPost={setEmptyPost} />
           </ContentsLayout>
           <TabMenu currentMenuId={4} />
         </>

--- a/src/pages/profilePage/ProfilePost/ProfilePost.jsx
+++ b/src/pages/profilePage/ProfilePost/ProfilePost.jsx
@@ -14,7 +14,7 @@ import { EMPTY_POST_IMAGE } from '../../../styles/CommonImages';
 import Loading from '../../../components/common/Loading/Loading';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 
-const ProfilePost = () => {
+const ProfilePost = ({ setEmptyPost }) => {
   let { accountname } = useParams();
   const navigate = useNavigate();
   const { userToken, userAccountname } = useContext(AuthContextStore);
@@ -41,12 +41,16 @@ const ProfilePost = () => {
         .then((res) => {
           setIsLoading(false);
           setMyPost(res.data.post);
+
+          if (res.data.post.length === 0) {
+            setEmptyPost(true);
+          }
         })
         .catch((err) => {
           setIsLoading(false);
           console.log(err);
         });
-      };
+    };
     getMyPost();
   }, [userToken, accountname, userAccountname]);
 
@@ -183,11 +187,11 @@ const PostGrid = styled.ul`
 `;
 
 const NoPost = styled.div`
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 53em;
   background-color: var(--chat-bg-color);
 
   & img {


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 프로필페이지 피드 게시글이 없을 때 세로로 긴 화면에서 공간이 남아 보이는 현상 해결을 위해 추가했습니다.


## 기대 결과
- 세로로 긴 디바이스에서도 피드 게시글이 없을 때 화면에 꽉 차서 보입니다.


## 리뷰어에게 전달 사항
- 게시글이 없을 때만 ContentLayout에 isFill=true를 전달합니다.
- ContentLayout에 isFill=true을 전달하면 ContentLayout이 100vh-110px만큼의 공간을 차지합니다.
- 기본값은 isFill=false입니다.


## 스크린샷
### 수정 전
![스크린샷 2022-12-29 오전 9 19 30](https://user-images.githubusercontent.com/105365737/209890112-e7b2aa22-5b19-4f2f-bf16-b89adf475557.png)

### 수정 후
![스크린샷 2022-12-29 오전 9 20 41](https://user-images.githubusercontent.com/105365737/209890118-7cf9d2ef-e43a-4adf-88b9-52660b96483c.png)


## 관련 이슈 번호
close : #367 
