### PR TITLE
fix: 판매 링크 입력 시 주소를 복사해서 넣으면 생기는 버그 수정 (#365)

### DIFF
--- a/src/pages/ProductModificationPage/ProductModificationPage.jsx
+++ b/src/pages/ProductModificationPage/ProductModificationPage.jsx
@@ -24,7 +24,12 @@ const ProductModificationPage = () => {
 
   const [linkMod, setLinkMod] = useState('');
   const linkModFunction = (value) => {
-    setLinkMod(value);
+    const urlRegex = /(http(s)?:\/\/)([a-z0-9\w]+\.*)+[a-z0-9]{2,4}/gi;
+    if (urlRegex.test(value)) {
+      setLinkMod(value);
+    } else {
+      setLinkMod('');
+    }
   };
   // console.log(linkMod);
 

--- a/src/pages/ProductRegistrationPage/ItemLinkInput.jsx
+++ b/src/pages/ProductRegistrationPage/ItemLinkInput.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import styled from 'styled-components';
 
 // * 사용법 - 아래의 4가지 props를 전달해줘야 합니다 *
@@ -16,10 +16,16 @@ const ItemLinkInput = ({
   linkMod,
 }) => {
   const [inputValue, setInputValue] = useState('');
-  const [isShowAlert, setIsShowAlert] = useState(false);
   const inputRef = useRef();
 
-  const [LinkValid, setLinkValid] = useState(false);
+  const [value, setValue] = useState('');
+  useEffect(() => {
+    if (linkMod) {
+      setValue(linkMod);
+    } else {
+      setValue(inputValue);
+    }
+  }, [inputValue, linkMod]);
 
   const handleChange = (e) => {
     setInputValue(e.target.value);
@@ -30,26 +36,10 @@ const ItemLinkInput = ({
       inputRef.current.style.borderBottom = '1px solid var(--border-color)';
     }
 
-    const regex = /(http(s)?:\/\/)([a-z0-9\w]+\.*)+[a-z0-9]{2,4}/gi;
-
-    if (regex.test(e.target.value)) {
-      setLinkValid(true);
-    } else {
-      setLinkValid(false);
-    }
-
     if (linkModFunction) {
-      if (LinkValid) {
-        linkModFunction(e.target.value);
-      } else {
-        linkModFunction('');
-      }
+      linkModFunction(e.target.value);
     } else {
-      if (LinkValid) {
-        linkFunction(e.target.value);
-      } else {
-        linkFunction('');
-      }
+      linkFunction(e.target.value);
     }
   };
 
@@ -60,12 +50,11 @@ const ItemLinkInput = ({
         type={inputType}
         id={id}
         placeholder={placeholder}
-        // value={inputValue}
+        value={value}
         onChange={handleChange}
         ref={inputRef}
         autoComplete='off'
         spellCheck='false'
-        defaultValue={linkMod}
       />
     </InputWrapper>
   );

--- a/src/pages/ProductRegistrationPage/ProductRegistrationPage.jsx
+++ b/src/pages/ProductRegistrationPage/ProductRegistrationPage.jsx
@@ -35,7 +35,12 @@ const ProductRegistrationPage = ({
 
   const [link, setLink] = useState('');
   const linkFunction = (value) => {
-    setLink(value);
+    const urlRegex = /(http(s)?:\/\/)([a-z0-9\w]+\.*)+[a-z0-9]{2,4}/gi;
+    if (urlRegex.test(value)) {
+      setLink(value);
+    } else {
+      setLink('');
+    }
   };
 
   const [itemImage, setItemImage] = useState('');


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 그냥 타이핑해서 올바른 주소를 입력하면 버튼이 정상적으로 활성화되지만, 주소를 복사해서 입력하면 바로 활성화되지 않고 해당 인풋창에 입력 값의 변화를 한 번 더 줘야 버튼이 활성화되었던 부분을 수정했습니다.


## 기대 결과
- 판매 링크 입력창의 정상적인 작동을 기대할 수 있습니다.


## 리뷰어에게 전달 사항
- 이제 복붙해도 정상 작동합니다.
- 추후 리팩토링이 진행될 수 있습니다.


## 관련 이슈 번호
close : #365 
