### PR TITLE
fix: 팔로워, 팔로잉 리스트가 최대 10개까지만 보이는 현상 (#361)

### DIFF
--- a/src/pages/FollowListPage/FollowListPage.jsx
+++ b/src/pages/FollowListPage/FollowListPage.jsx
@@ -33,7 +33,7 @@ const FollowListPage = () => {
       }
 
       const option = {
-        url: `https://mandarin.api.weniv.co.kr/profile/${accountname}/${type}`,
+        url: `https://mandarin.api.weniv.co.kr/profile/${accountname}/${type}?limit=0`,
         method: 'GET',
         headers: { Authorization: `Bearer ${userToken}`, 'Content-type': 'application/json' },
       };


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 팔로워, 팔로잉 리스트가 최대 10개까지만 보이는 현상 해결


## 기대 결과
- 팔로워, 팔로잉 리스트를 모두 확인할 수 있습니다.


## 리뷰어에게 전달 사항
- limit는 고정하고 skip을 추가하는 방식으로 우회하여 무한스크롤을 구현해보려고 했으나 이 방법으로 API 테스트 시에도 순서가 뒤죽박죽 되는 것으로 확인되었습니다.
- 결국 처음 말했던대로 전체 리스트를 가져오는 방식으로 임시 조치를 취했습니다.



## 관련 이슈 번호
close : #361 
