### PR TITLE
fix: 앨범형 게시글 클릭 시 포스트 디테일로 이동하게 수정 (#374)

### DIFF
--- a/src/pages/profilePage/ProfilePost/ProfilePost.jsx
+++ b/src/pages/profilePage/ProfilePost/ProfilePost.jsx
@@ -12,7 +12,7 @@ import {
 } from '../../../styles/CommonIcons';
 import { EMPTY_POST_IMAGE } from '../../../styles/CommonImages';
 import Loading from '../../../components/common/Loading/Loading';
-import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
 
 const ProfilePost = ({ setEmptyPost }) => {
   let { accountname } = useParams();
@@ -90,12 +90,16 @@ const ProfilePost = ({ setEmptyPost }) => {
                   return post.image ? (
                     post.image.includes(',') ? (
                       <li>
-                        <img key={post.id} src={post.image.split(',')[0]} alt='썸네일 이미지' />
-                        <img className='layer-icon' src={LAYERS_ICON} alt='레이어 아이콘' />
+                        <Link to={`/post/${post.id}`}>
+                          <img key={post.id} src={post.image.split(',')[0]} alt='썸네일 이미지' />
+                          <img className='layer-icon' src={LAYERS_ICON} alt='레이어 아이콘' />
+                        </Link>
                       </li>
                     ) : (
                       <>
-                        <img key={post.id} src={post.image} alt='썸네일 이미지'></img>
+                        <Link to={`/post/${post.id}`}>
+                          <img key={post.id} src={post.image} alt='썸네일 이미지'></img>
+                        </Link>
                       </>
                     )
                   ) : null;

--- a/src/pages/profilePage/ProfileProduct/ProfileProduct.jsx
+++ b/src/pages/profilePage/ProfileProduct/ProfileProduct.jsx
@@ -39,7 +39,7 @@ const ProfileProduct = () => {
   };
   useEffect(() => {
     getProduct();
-  }, [userToken, accountname]);
+  }, [userToken, accountname, productList]);
 
   return (
     <>

--- a/src/pages/profilePage/ProfileProduct/ProfileProduct.jsx
+++ b/src/pages/profilePage/ProfileProduct/ProfileProduct.jsx
@@ -39,7 +39,7 @@ const ProfileProduct = () => {
   };
   useEffect(() => {
     getProduct();
-  }, [userToken, accountname, productList]);
+  }, [userToken, accountname]);
 
   return (
     <>


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 앨범형 리스트에서 이미지 클릭시 포스트 디테일로 이동하지 않는 현상이 있어 Link 태그를 넣었습니다


## 기대 결과
- 이제 클릭하면 게시글 상세를 볼 수 있습니다


## 관련 이슈 번호
close : #374 
