### PR TITLE
style: 프로필 소개글 양쪽 여백 스타일 추가 (#378)

### DIFF
--- a/src/pages/profilePage/ProfileHeader/ProfileHeader.jsx
+++ b/src/pages/profilePage/ProfileHeader/ProfileHeader.jsx
@@ -74,6 +74,8 @@ const ProfileWrapper = styled.header`
   flex-direction: column;
   position: relative;
   margin-top: 3em;
+  padding-left: 2em;
+  padding-right: 2em;
 `;
 
 const UserName = styled.strong`


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 소개글이 길 경우 양쪽에 여백 없이 붙어버리는 현상이 발생해서 padding 값 추가했습니다


## 스크린샷
<img width="485" alt="image" src="https://user-images.githubusercontent.com/96304623/209897779-750adf62-825a-4fd5-9d36-c14e0b45b10a.png">



## 관련 이슈 번호
close : #378
