### PR TITLE
feat: 커뮤니티 메인 페이지 무한 스크롤 구현 및 추천글 정렬 기준 변경 (#369, #370)

### DIFF
--- a/src/pages/communityPage/CommunityMainPage/CommunityMainPage.jsx
+++ b/src/pages/communityPage/CommunityMainPage/CommunityMainPage.jsx
@@ -10,7 +10,6 @@ import PopularPosts from './PopularPosts';
 import CommunityLayout from '../CommunityLayout';
 
 const CommunityMainPage = () => {
-  const [isLoading, setIsLoading] = useState(true);
   const [isEmpty, setIsEmpty] = useState(true);
 
   const advertisingImageList = [
@@ -20,23 +19,14 @@ const CommunityMainPage = () => {
     { id: 3, src: ADVERTISING4_IMAGE, alt: '현재 위치에서 가장 가까운 동물병원 찾기 서비스 오픈!' },
   ];
 
-  const changeLoadingState = (loadingState) => {
-    setIsLoading(loadingState);
-  };
-
   const changeEmptyState = (emptyState) => {
     setIsEmpty(emptyState);
   };
 
   return (
-    <CommunityLayout currentMenuId={0} fillHeight={isLoading ? true : isEmpty ? true : false}>
+    <CommunityLayout currentMenuId={0} fillHeight={isEmpty}>
       <PaginationCarousel itemList={advertisingImageList} />
-      <PopularPosts
-        isLoading={isLoading}
-        isEmpty={isEmpty}
-        changeLoadingState={changeLoadingState}
-        changeEmptyState={changeEmptyState}
-      />
+      <PopularPosts isEmpty={isEmpty} changeEmptyState={changeEmptyState} />
     </CommunityLayout>
   );
 };

--- a/src/pages/communityPage/CommunityMainPage/PopularPosts.jsx
+++ b/src/pages/communityPage/CommunityMainPage/PopularPosts.jsx
@@ -11,7 +11,7 @@ const PopularPosts = ({ isEmpty, changeEmptyState }) => {
     threshold: 0,
   });
   const [page, setPage] = useState(0);
-  const [loading, setLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   const { userToken, userAccountname } = useContext(AuthContextStore);
   const [emptyFeedPosts, setEmptyFeedPosts] = useState(false);
@@ -60,7 +60,7 @@ const PopularPosts = ({ isEmpty, changeEmptyState }) => {
   }, [page]);
 
   useEffect(() => {
-    setLoading(true);
+    setIsLoading(true);
 
     const getPopularPosts = async () => {
       const feedPosts = !emptyFeedPosts ? await getFeedPosts() : [];
@@ -91,16 +91,16 @@ const PopularPosts = ({ isEmpty, changeEmptyState }) => {
     };
 
     getPopularPosts();
-    setLoading(false);
+    setIsLoading(false);
   }, [getFeedPosts, getMyPosts]);
 
   useEffect(() => {
-    if (!inView || loading) {
+    if (!inView || isLoading) {
       return;
     }
 
     setPage((prev) => prev + 10);
-  }, [inView, loading]);
+  }, [inView, isLoading]);
 
   return (
     <PopularPostsSection>
@@ -111,7 +111,7 @@ const PopularPosts = ({ isEmpty, changeEmptyState }) => {
         <EmptyPosts />
       ) : (
         <PostWrapper>
-          {recommendPosts.map((post, i) => (
+          {recommendPosts.map((post) => (
             <Post key={post.id} post={post} />
           ))}
           {emptyFeedPosts && emptyMyPosts ? <></> : <div ref={ref} />}

--- a/src/pages/communityPage/CommunityMainPage/PopularPosts.jsx
+++ b/src/pages/communityPage/CommunityMainPage/PopularPosts.jsx
@@ -1,74 +1,120 @@
 import axios from 'axios';
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState, useCallback } from 'react';
+import { useInView } from 'react-intersection-observer';
 import styled from 'styled-components';
-import Loading from '../../../components/common/Loading/Loading';
 import { AuthContextStore } from '../../../context/AuthContext';
 import Post from './../../../components/common/Post/Post';
 import EmptyPosts from './EmptyPosts';
 
-const PopularPosts = ({ isLoading, isEmpty, changeLoadingState, changeEmptyState }) => {
+const PopularPosts = ({ isEmpty, changeEmptyState }) => {
+  const [ref, inView] = useInView({
+    threshold: 0,
+  });
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(false);
+
   const { userToken, userAccountname } = useContext(AuthContextStore);
-  const [popularPosts, setPopularPosts] = useState([]);
+  const [emptyFeedPosts, setEmptyFeedPosts] = useState(false);
+  const [emptyMyPosts, setEmptyMyPosts] = useState(false);
+  const [recommendPosts, setRecommendPosts] = useState([]);
   const BASE_URL = 'https://mandarin.api.weniv.co.kr';
 
   useEffect(() => {
-    const getFeedPosts = async () => {
-      const header = { headers: { Authorization: `Bearer ${userToken}`, 'Content-type': 'application/json' } };
+    window.scrollTo(0, 0);
+  }, []);
 
-      await axios
-        .all([
-          axios.get(BASE_URL + '/post/feed', header),
-          axios.get(BASE_URL + `/post/${userAccountname}/userpost`, header),
-        ])
-        .then(
-          axios.spread((res1, res2) => {
-            const feedPosts = res1.data.posts;
-            const myPosts = res2.data.post;
-            const posts = [...feedPosts, ...myPosts];
+  const getFeedPosts = useCallback(async () => {
+    let feedPosts = [];
 
-            if (posts.length > 0) {
-              changeEmptyState(false);
-              sortPopularPosts(posts);
-            }
+    await axios
+      .get(BASE_URL + `/post/feed?limit=10&skip=${page}`, {
+        headers: { Authorization: `Bearer ${userToken}`, 'Content-type': 'application/json' },
+      })
+      .then((res) => {
+        feedPosts = res.data.posts;
 
-            changeLoadingState(false);
-          }),
-        );
+        if (feedPosts.length < 5) {
+          setEmptyFeedPosts(true);
+        }
+      });
+
+    return feedPosts;
+  }, [page]);
+
+  const getMyPosts = useCallback(async () => {
+    let myPosts = [];
+
+    await axios
+      .get(BASE_URL + `/post/${userAccountname}/userpost?limit=10&skip=${page}`, {
+        headers: { Authorization: `Bearer ${userToken}`, 'Content-type': 'application/json' },
+      })
+      .then((res) => {
+        myPosts = res.data.post;
+
+        if (myPosts.length < 5) {
+          setEmptyMyPosts(true);
+        }
+      });
+
+    return myPosts;
+  }, [page]);
+
+  useEffect(() => {
+    setLoading(true);
+
+    const getPopularPosts = async () => {
+      const feedPosts = !emptyFeedPosts ? await getFeedPosts() : [];
+      const myPosts = !emptyMyPosts ? await getMyPosts() : [];
+
+      const posts = [...feedPosts, ...myPosts];
+
+      if (posts.length > 0) {
+        changeEmptyState(false);
+
+        const sortPosts = sortingPosts(posts);
+        setRecommendPosts((prev) => prev.concat(sortPosts));
+      }
     };
 
-    const sortPopularPosts = (posts) => {
+    const sortingPosts = (posts) => {
       const sortPosts = posts.sort((a, b) => {
+        if (a.heartCount + a.commentCount > b.heartCount + b.commentCount) return -1;
+        if (a.heartCount + a.commentCount < b.heartCount + b.commentCount) return 1;
         if (a.heartCount > b.heartCount) return -1;
         if (a.heartCount < b.heartCount) return 1;
-        if (a.commentCount > b.commentCount) return -1;
-        if (a.commentCount < b.commentCount) return 1;
         if (a.createdAt > b.createdAt) return -1;
         if (a.createdAt < b.createdAt) return 1;
         return 0;
       });
 
-      setPopularPosts(sortPosts);
+      return sortPosts;
     };
 
-    getFeedPosts();
-  }, []);
+    getPopularPosts();
+    setLoading(false);
+  }, [getFeedPosts, getMyPosts]);
+
+  useEffect(() => {
+    if (!inView || loading) {
+      return;
+    }
+
+    setPage((prev) => prev + 10);
+  }, [inView, loading]);
 
   return (
     <PopularPostsSection>
       <Header>
-        <Title>실시간 인기글</Title>
+        <Title>오늘의 추천글</Title>
       </Header>
-      {isLoading ? (
-        <LoadingWrapper>
-          <Loading />
-        </LoadingWrapper>
-      ) : isEmpty ? (
+      {isEmpty ? (
         <EmptyPosts />
       ) : (
         <PostWrapper>
-          {popularPosts.map((post) => (
+          {recommendPosts.map((post, i) => (
             <Post key={post.id} post={post} />
           ))}
+          {emptyFeedPosts && emptyMyPosts ? <></> : <div ref={ref} />}
         </PostWrapper>
       )}
     </PopularPostsSection>
@@ -90,13 +136,6 @@ const Header = styled.header`
 const Title = styled.h2`
   padding: 1.6rem 0 1.6rem 1.6rem;
   font-size: var(--fs-lg);
-`;
-
-const LoadingWrapper = styled.div`
-  flex: 1;
-  display: flex;
-  justify-content: center;
-  align-items: center;
 `;
 
 const PostWrapper = styled.div`


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [x] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 커뮤니티 메인 페이지에서 게시물이 최대 20개까지만 보이는 문제 해결을 위해 무한 스크롤 기능 추가
- API의 한계로 인해 문구를 **실시간 인기글**이 아니라 **오늘의 추천글**로 변경


## 기대 결과
- 커뮤니티 메인 페이지에서 피드 게시물 + 내 게시물을 **일부 정렬된 형태**로 볼 수 있습니다.


## 리뷰어에게 전달 사항
- 기존 : 게시물 20개를 미리 가져온 후 => 가져온 게시물 안에서 하트수, 댓글수, 최신순으로 정렬함 (즉 인기글처럼 보이게 가공 가능했음)
- 무한스크롤 구현 후 : 스크롤을 한 번 내릴때마다 게시물을 최대 20개씩 가져옴 => 그러다보니 모든 게시물을 하트수, 댓글수, 최신순으로 정렬해서 보여주는게 불가능. (모든 게시물을 하트순 정렬 / 댓글순 정렬해서 반환해주는 API는 존재하지 않음)
- 따라서 스크롤 한 번 내릴때 추가되는 게시물 안에서만 정렬했고, 문구를 **오늘의 추천글**로 바꿈
```
예)
최초 스크롤시 : 가져온 게시물 안에서만 하트+댓글이 많은 순서대로 정렬
두번째 스크롤시 : 새로 가져온 게시물 안에서만 하트+댓글이 많은 순서대로 정렬
반복
...
```

## 스크린샷
![Dec-29-2022 14-03-06](https://user-images.githubusercontent.com/105365737/209908550-77a6c1dd-d67c-4881-9d12-8275e2377287.gif)

## 관련 이슈 번호
close : #369 
