### PR TITLE
fix: 피드 페이지 코드 누락으로 게시물이 없을 때 공간이 남아 보이는 현상 (#387)

### DIFF
--- a/src/pages/profilePage/ProfilePage.jsx
+++ b/src/pages/profilePage/ProfilePage.jsx
@@ -66,7 +66,7 @@ const ProfilePage = () => {
       ) : (
         <>
           <TopBasicNav />
-          <ContentsLayout padding='2rem 0 0 0'>
+          <ContentsLayout padding='2rem 0 0 0' isFill={emptyPost}>
             <ProfileHeader profileData={userProfileInfo} profileUserAccountname={accountname} />
             <ProfileProduct />
             <ProfilePost setEmptyPost={setEmptyPost} />


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 피드 페이지 게시물이 없을 때 공간이 남아 보이는 현상 해결을 위해 누락된 코드 추가


## 기대 결과
- 게시물이 없어도 화면에 꽉 차보입니다.


## 스크린샷
![스크린샷 2022-12-29 오후 3 40 04](https://user-images.githubusercontent.com/105365737/209913823-6cc03fce-d563-49f3-a57a-d0c853643135.png)


## 관련 이슈 번호
close : #387 
