### PR TITLE
bug: 프로필 페이지에서 게시물이 없고 상품이 있는 경우 ProfilePost 영역이 작아지는 현상 (#390)

### DIFF
--- a/src/components/layout/ContentsLayout/ContentsLayout.jsx
+++ b/src/components/layout/ContentsLayout/ContentsLayout.jsx
@@ -24,5 +24,5 @@ const ContentsWrapper = styled.main`
   padding: ${(props) => props.padding};
 
   /* 프로필 페이지를 위한 커스텀 */
-  ${(props) => (props.emptyProfileState === 'twice' ? 'height: calc(100vh - 110px);' : 'height: auto;')}
+  ${(props) => (props.emptyProfileState === 'twice' ? 'height: calc(100vh - 110px);' : 'post' ? 'height: auto;' : '')}
 `;

--- a/src/components/layout/ContentsLayout/ContentsLayout.jsx
+++ b/src/components/layout/ContentsLayout/ContentsLayout.jsx
@@ -24,5 +24,5 @@ const ContentsWrapper = styled.main`
   padding: ${(props) => props.padding};
 
   /* 프로필 페이지를 위한 커스텀 */
-  ${(props) => (props.emptyProfileState === 'twice' ? 'height: calc(100vh - 110px);' : 'post' ? 'height: auto;' : '')}
+  ${(props) => (props.emptyProfileState === 'twice' ? 'height: calc(100vh - 110px);' : '')}
 `;

--- a/src/components/layout/ContentsLayout/ContentsLayout.jsx
+++ b/src/components/layout/ContentsLayout/ContentsLayout.jsx
@@ -6,9 +6,9 @@ import styled from 'styled-components';
 // * 사용법 - 2가지 props를 전달해줘야 합니다 *
 // isTabMenu : 탭 메뉴 존재 여부를 boolean 값으로 전달해야 합니다. true인 경우 margin-bottom: 6rem이 적용됩니다. 기본값은 true입니다.
 // padding : 적용할 패딩을 문자열 값으로 전달해야 합니다. 이때 단축 속성으로 전달해야 합니다. 기본값은 상단 2rem, 좌우 1.6rem으로 적용되어 있습니다.
-const ContentsLayout = ({ children, isTabMenu = true, padding = '2rem 1.6rem 0 1.6rem' }) => {
+const ContentsLayout = ({ children, isTabMenu = true, padding = '2rem 1.6rem 0 1.6rem', emptyProfileState = null }) => {
   return (
-    <ContentsWrapper isTabMenu={isTabMenu} padding={padding}>
+    <ContentsWrapper isTabMenu={isTabMenu} padding={padding} emptyProfileState={emptyProfileState}>
       {children}
     </ContentsWrapper>
   );
@@ -22,4 +22,7 @@ const ContentsWrapper = styled.main`
   margin-top: 4.8rem;
   margin-bottom: ${(props) => (props.isTabMenu ? '6rem' : 0)};
   padding: ${(props) => props.padding};
+
+  /* 프로필 페이지를 위한 커스텀 */
+  ${(props) => (props.emptyProfileState === 'twice' ? 'height: calc(100vh - 110px);' : 'height: auto;')}
 `;

--- a/src/components/layout/ContentsLayout/ContentsLayout.jsx
+++ b/src/components/layout/ContentsLayout/ContentsLayout.jsx
@@ -6,9 +6,9 @@ import styled from 'styled-components';
 // * 사용법 - 2가지 props를 전달해줘야 합니다 *
 // isTabMenu : 탭 메뉴 존재 여부를 boolean 값으로 전달해야 합니다. true인 경우 margin-bottom: 6rem이 적용됩니다. 기본값은 true입니다.
 // padding : 적용할 패딩을 문자열 값으로 전달해야 합니다. 이때 단축 속성으로 전달해야 합니다. 기본값은 상단 2rem, 좌우 1.6rem으로 적용되어 있습니다.
-const ContentsLayout = ({ children, isTabMenu = true, padding = '2rem 1.6rem 0 1.6rem', isFill = false }) => {
+const ContentsLayout = ({ children, isTabMenu = true, padding = '2rem 1.6rem 0 1.6rem' }) => {
   return (
-    <ContentsWrapper isTabMenu={isTabMenu} padding={padding} isFill={isFill}>
+    <ContentsWrapper isTabMenu={isTabMenu} padding={padding}>
       {children}
     </ContentsWrapper>
   );
@@ -19,7 +19,6 @@ export default ContentsLayout;
 const ContentsWrapper = styled.main`
   display: flex;
   flex-direction: column;
-  ${(props) => (props.isFill ? 'height: calc(100vh - 110px);' : '')};
   margin-top: 4.8rem;
   margin-bottom: ${(props) => (props.isTabMenu ? '6rem' : 0)};
   padding: ${(props) => props.padding};

--- a/src/pages/profilePage/ProfilePage.jsx
+++ b/src/pages/profilePage/ProfilePage.jsx
@@ -66,7 +66,7 @@ const ProfilePage = () => {
       ) : (
         <>
           <TopBasicNav />
-          <ContentsLayout padding='2rem 0 0 0' isFill={emptyPost}>
+          <ContentsLayout padding='2rem 0 0 0'>
             <ProfileHeader profileData={userProfileInfo} profileUserAccountname={accountname} />
             <ProfileProduct />
             <ProfilePost setEmptyPost={setEmptyPost} />

--- a/src/pages/profilePage/ProfilePage.jsx
+++ b/src/pages/profilePage/ProfilePage.jsx
@@ -20,6 +20,7 @@ const ProfilePage = () => {
   let { accountname } = useParams();
   const [isLoading, setIsLoading] = useState(true);
   const [emptyPost, setEmptyPost] = useState(false);
+  const [emptyProduct, setEmptyProduct] = useState(false);
 
   // 유저의 프로필 정보 담기
   const [userProfileInfo, setUserProfileInfo] = useState('');
@@ -66,10 +67,13 @@ const ProfilePage = () => {
       ) : (
         <>
           <TopBasicNav />
-          <ContentsLayout padding='2rem 0 0 0'>
+          <ContentsLayout
+            padding='2rem 0 0 0'
+            emptyProfileState={emptyPost && emptyProduct ? 'twice' : emptyPost ? 'post' : null}
+          >
             <ProfileHeader profileData={userProfileInfo} profileUserAccountname={accountname} />
-            <ProfileProduct />
-            <ProfilePost setEmptyPost={setEmptyPost} />
+            <ProfileProduct setEmptyProduct={setEmptyProduct} />
+            <ProfilePost setEmptyPost={setEmptyPost} emptyProduct={emptyProduct} />
           </ContentsLayout>
           <TabMenu currentMenuId={4} />
         </>

--- a/src/pages/profilePage/ProfilePost/ProfilePost.jsx
+++ b/src/pages/profilePage/ProfilePost/ProfilePost.jsx
@@ -147,8 +147,6 @@ const PostHeader = styled.section`
   border-bottom: 0.5px solid var(--border-color);
 `;
 
-const PostContents = styled.div``;
-
 const ListIcon = styled.button`
   background: no-repeat center / 20px;
   width: 26px;
@@ -196,6 +194,7 @@ const NoPost = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  min-height: 60em;
   background-color: var(--chat-bg-color);
 
   & img {

--- a/src/pages/profilePage/ProfilePost/ProfilePost.jsx
+++ b/src/pages/profilePage/ProfilePost/ProfilePost.jsx
@@ -15,8 +15,6 @@ import Loading from '../../../components/common/Loading/Loading';
 import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
 
 const ProfilePost = ({ setEmptyPost, emptyProduct }) => {
-  console.log(emptyProduct);
-
   let { accountname } = useParams();
   const navigate = useNavigate();
   const { userToken, userAccountname } = useContext(AuthContextStore);

--- a/src/pages/profilePage/ProfilePost/ProfilePost.jsx
+++ b/src/pages/profilePage/ProfilePost/ProfilePost.jsx
@@ -14,7 +14,9 @@ import { EMPTY_POST_IMAGE } from '../../../styles/CommonImages';
 import Loading from '../../../components/common/Loading/Loading';
 import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
 
-const ProfilePost = ({ setEmptyPost }) => {
+const ProfilePost = ({ setEmptyPost, emptyProduct }) => {
+  console.log(emptyProduct);
+
   let { accountname } = useParams();
   const navigate = useNavigate();
   const { userToken, userAccountname } = useContext(AuthContextStore);
@@ -107,7 +109,7 @@ const ProfilePost = ({ setEmptyPost }) => {
               </PostGrid>
             )
           ) : (
-            <NoPost>
+            <NoPost emptyProduct={emptyProduct}>
               <img src={EMPTY_POST_IMAGE} alt='포스트가 존재하지 않습니다' />
               <span>아직 작성된 게시글이 없어요.</span>
             </NoPost>
@@ -194,7 +196,7 @@ const NoPost = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 60em;
+  ${(props) => (props.emptyProduct ? '' : 'min-height: 60em;')}
   background-color: var(--chat-bg-color);
 
   & img {

--- a/src/pages/profilePage/ProfileProduct/ProfileProduct.jsx
+++ b/src/pages/profilePage/ProfileProduct/ProfileProduct.jsx
@@ -7,7 +7,7 @@ import { AuthContextStore } from '../../../context/AuthContext';
 import { useNavigate, useParams } from 'react-router-dom';
 import Loading from '../../../components/common/Loading/Loading';
 
-const ProfileProduct = () => {
+const ProfileProduct = ({ setEmptyProduct }) => {
   let { accountname } = useParams();
   const navigate = useNavigate();
   const { userToken, userAccountname } = useContext(AuthContextStore);
@@ -30,6 +30,11 @@ const ProfileProduct = () => {
     })
       .then((res) => {
         setIsLoading(false);
+
+        if (res.data.product.length === 0) {
+          setEmptyProduct(true);
+        }
+
         setProductList(res.data.product);
       })
       .catch((err) => {


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 프로필 페이지에서 게시물이 없고 상품이 있는 경우 ProfilePost 영역이 작아지는 현상 해결을 위함


## 기대 결과
- 프로필 페이지에서 게시물이 없고 상품이 있는 경우 영역이 작아지는 현상이 해결됨


## 리뷰어에게 전달사항
- empty게시물, empty 상품 상태에 따라 레이아웃을 다르게 잡는 emptyProfileState 추가. 기본값 null
- 게시물X 상품X : 테스트 완료
- 게시물O 상품X : 테스트 완료
- 게시물X 상품O : 테스트 완료


## 관련 이슈 번호
close : #390 
