### PR TITLE
style: ProfileProduct 캐러셀 높이값 조정 (#391)

### DIFF
--- a/src/components/carousel/MultiItemCarousel/multiItemCarousel.css
+++ b/src/components/carousel/MultiItemCarousel/multiItemCarousel.css
@@ -1,5 +1,9 @@
 .mySwiper {
-  height: 180px;
+  height: 170px;
+}
+
+.swiper-section {
+  padding-bottom: 0;
 }
 
 .swiper-pagination-bullet.swiper-pagination-bullet-active {


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 판매하는 상품이 1-2개일 경우 하단의 여백이 너무 길어서 허전해보였습니다. 


## 기대 결과
- 높이값을 조금 조정했습니다
- (사실 캐러셀 버튼을 한개라도 띄우고 싶어서 이것저것 조정 해보았으나 잘 되지 않았습니다. 추후 가능하다면 수정해보겠습니다 ㅠㅠ)


## 스크린샷
<img width="486" alt="image" src="https://user-images.githubusercontent.com/96304623/209923137-73ceea1f-df1f-48e7-aec1-051886e9d850.png">



## 관련 이슈 번호
close : #391 
