### PR TITLE
feat: 카카오톡 프로필 공유시 이미지 추가 및 소개글 수정 (#399)

### DIFF
--- a/src/pages/profilePage/ProfileHeader/UserProfileBtns.jsx
+++ b/src/pages/profilePage/ProfileHeader/UserProfileBtns.jsx
@@ -81,9 +81,9 @@ const UserProfileBtns = ({ profileData, profileUserAccountname }) => {
       kakao.Link.sendDefault({
         objectType: 'feed',
         content: {
-          title: '가져도댕냥',
-          description: '우리집 댕냥이를 위한 따뜻한 선물',
-          imageUrl: '',
+          title: `${profileData.username}님의 프로필 - 가져도댕냥`,
+          description: `우리집 댕냥이를 위한 따뜻한 선물! ${profileData.username}님의 프로필이 공유되었습니다. `,
+          imageUrl: 'https://mandarin.api.weniv.co.kr/1672125328324.png',
           link: {
             webUrl: 'http://localhost:3000/',
           },


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 이전에는 기능 구현에만 초점을 맞추어 디자인이 다소 밋밋했습니다. 리팩토링 단계에서 이미지나 소개글을 추가해보았습니다.


## 기대 결과
- 자세한 소개글과 귀여운 냥그리의 이미지를 공유하여 사용자들에게 호기심을 유발할 수 있고, 이는 사용자수 증가에 크게 기여할 수 있습니다. 


## 스크린샷
`기존이미지`
![image](https://user-images.githubusercontent.com/96304623/209981448-07719440-d930-468c-87d9-f53ce116f0ed.png)

`업데이트 후 이미지 `
<img width="342" alt="image" src="https://user-images.githubusercontent.com/96304623/209981359-9d3c2c9e-c28a-42c2-9df9-9a59db483abd.png">


## 관련 이슈 번호
close : #399
