### PR TITLE
fix: 프로필 수정시 바로 업데이트 되지 않는 버그 해결 (#398)

### DIFF
--- a/src/components/common/Button/Button.jsx
+++ b/src/components/common/Button/Button.jsx
@@ -5,6 +5,7 @@ const Button = ({
   children,
   size,
   disabled,
+  type,
   backgroundColor = 'var(--login-bg-color)',
   borderColor = 'transparent',
   textColor = 'var(--main-bg-color)',
@@ -20,6 +21,7 @@ const Button = ({
       textColor={textColor}
       onClick={onClickHandler}
       isActive={isActive}
+      type={type}
     >
       {children}
     </StyledButton>

--- a/src/components/common/TopNavBar/TopUploadNav.jsx
+++ b/src/components/common/TopNavBar/TopUploadNav.jsx
@@ -5,7 +5,7 @@ import { TopNavBar, LeftArrow } from './Styled';
 import { LEFT_ARROW_ICON } from '../../../styles/CommonIcons';
 import Button from '../Button/Button';
 
-const TopUploadNav = ({ onClick, activeButton, activeModButton }) => {
+const TopUploadNav = ({ onClick, activeButton, activeModButton, type }) => {
   const navigate = useNavigate();
   const params = useParams();
 
@@ -19,7 +19,7 @@ const TopUploadNav = ({ onClick, activeButton, activeModButton }) => {
           저장
         </Button>
       ) : (
-        <Button disabled={activeButton} onClickHandler={onClick} size='MS'>
+        <Button disabled={activeButton} onClickHandler={onClick} type={type} size='MS'>
           저장
         </Button>
       )}

--- a/src/pages/ProfileModificationPage/ProfileModificationPage.jsx
+++ b/src/pages/ProfileModificationPage/ProfileModificationPage.jsx
@@ -44,7 +44,6 @@ const ProfileModificationPage = () => {
 
       axios(option)
         .then((res) => {
-          // console.log(res.data.user);
           setUserName(res.data.user.username);
           setDefaultAccountName(res.data.user.accountname);
           setAccountName(res.data.user.accountname);
@@ -75,7 +74,6 @@ const ProfileModificationPage = () => {
 
     axios(option)
       .then((res) => {
-        // console.log('프로필 수정 성공!!');
         navigate('/profile');
       })
       .catch((err) => {
@@ -90,7 +88,6 @@ const ProfileModificationPage = () => {
     } else {
       setDisabledButton(true);
     }
-    // console.log('render!!');
   }, [userName, accountName, intro]);
 
   return (

--- a/src/pages/ProfileModificationPage/ProfileModificationPage.jsx
+++ b/src/pages/ProfileModificationPage/ProfileModificationPage.jsx
@@ -1,5 +1,5 @@
 import { useContext, useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import styled from 'styled-components';
 import TopUploadNav from '../../components/common/TopNavBar/TopUploadNav';
@@ -9,7 +9,7 @@ import { AuthContextStore } from '../../context/AuthContext';
 
 const ProfileModificationPage = () => {
   const { userToken } = useContext(AuthContextStore);
-
+  const navigate = useNavigate();
   const [userName, setUserName] = useState('');
   const userNameFunction = (value) => {
     setUserName(value);
@@ -75,8 +75,8 @@ const ProfileModificationPage = () => {
 
     axios(option)
       .then((res) => {
-        console.log('프로필 수정 성공!!');
-        console.log(res);
+        // console.log('프로필 수정 성공!!');
+        navigate('/profile');
       })
       .catch((err) => {
         console.error(err);
@@ -95,9 +95,8 @@ const ProfileModificationPage = () => {
 
   return (
     <>
-      <Link to='/profile'>
-        <TopUploadNav activeButton={disabledButton} onClick={onClickSaveButtonHandler} />
-      </Link>
+      <TopUploadNav activeButton={disabledButton} onClick={onClickSaveButtonHandler} type={'submit'} />
+
       <ContentsLayout isTabMenu='false' padding='0'>
         <Section>
           <h2 className='sr-only'>프로필 정보 수정</h2>

--- a/src/pages/profilePage/ProfileHeader/UserProfileBtns.jsx
+++ b/src/pages/profilePage/ProfileHeader/UserProfileBtns.jsx
@@ -81,9 +81,9 @@ const UserProfileBtns = ({ profileData, profileUserAccountname }) => {
       kakao.Link.sendDefault({
         objectType: 'feed',
         content: {
-          title: '가져도댕냥',
-          description: '우리집 댕냥이를 위한 따뜻한 선물',
-          imageUrl: '',
+          title: `${profileData.username}님의 프로필 - 가져도댕냥`,
+          description: `우리집 댕냥이를 위한 따뜻한 선물! ${profileData.username}님의 프로필이 공유되었습니다. `,
+          imageUrl: 'https://mandarin.api.weniv.co.kr/1672125328324.png',
           link: {
             webUrl: 'http://localhost:3000/',
           },


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
-  프로필정보 변경시 바로 업데이트가 되지 않고, 새로고침을 해야 업데이트가 되는 현상을 수정했습니다.


## 기대 결과
- 이제 프로필 변경하면 바로 반영됩니다.


## 리뷰어에게 전달 사항
- Button에 `type` props가 생성되었습니다.


## 스크린샷

https://user-images.githubusercontent.com/96304623/209989752-41d0b4a3-5541-4ea1-9eac-724e54317ca2.mov



## 관련 이슈 번호
close : #398
