### PR TITLE
fix/feat: 동물병원 근처 동물병원이 최대 15개만 보이는 버그 수정 및 필터 유지 기능 추가 (#386, #404)

### DIFF
--- a/src/components/common/TopNavBar/TopTitleNav.jsx
+++ b/src/components/common/TopNavBar/TopTitleNav.jsx
@@ -6,7 +6,7 @@ import { TopNavBar, LeftArrow, MoreBtn } from './Styled';
 import { LEFT_ARROW_ICON, MORE_ICON } from '../../../styles/CommonIcons';
 import ChatRoomModal from '../modal/ChatRoomModal/ChatRoomModal';
 
-const TopTitleNav = ({ title, viewMoreBtn = true }) => {
+const TopTitleNav = ({ title, viewMoreBtn = true, isHospital = false }) => {
   const navigate = useNavigate();
 
   const [isOpenModal, setIsOpenModal] = useState(false);
@@ -15,10 +15,18 @@ const TopTitleNav = ({ title, viewMoreBtn = true }) => {
     setIsOpenModal(false);
   };
 
+  const goBack = () => {
+    if (isHospital) {
+      sessionStorage.setItem('hospital_back', true);
+    }
+
+    navigate(-1);
+  };
+
   return (
     <>
       <TopNavBar>
-        <button onClick={() => navigate(-1)}>
+        <button onClick={goBack}>
           <LeftArrow src={LEFT_ARROW_ICON} alt='뒤로가기 버튼' />
         </button>
         <TopNavH2>{title}</TopNavH2>

--- a/src/hooks/useCurrentLocation.jsx
+++ b/src/hooks/useCurrentLocation.jsx
@@ -36,7 +36,9 @@ const useCurrentLocation = ({ isLocationUpdate, setIsLocationUpdate }) => {
   };
 
   useEffect(() => {
-    getLocation();
+    if (isLocationUpdate) {
+      getLocation();
+    }
   }, [isLocationUpdate]);
 
   useEffect(() => {

--- a/src/pages/communityPage/CommunityHospitalPage/CommunityHospitalMainPage/CommunityHospitalMainPage.jsx
+++ b/src/pages/communityPage/CommunityHospitalPage/CommunityHospitalMainPage/CommunityHospitalMainPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import CommunityLayout from '../../CommunityLayout';
 import HospitalList from './HospitalList';
@@ -27,6 +27,18 @@ const CommunityHospitalMainPage = () => {
     setSelectFilterId(filterId);
     onClickBackgroundHandler();
   };
+
+  useEffect(() => {
+    const isBack = sessionStorage.getItem('hospital_back');
+
+    if (!isBack) {
+      sessionStorage.setItem('hospital_filter', 0);
+      return;
+    }
+
+    setSelectFilterId(sessionStorage.getItem('hospital_filter'));
+    sessionStorage.removeItem('hospital_back');
+  }, []);
 
   return (
     <CommunityLayout padding='0' currentMenuId={2}>

--- a/src/pages/communityPage/CommunityHospitalPage/CommunityHospitalMainPage/CommunityHospitalMainPage.jsx
+++ b/src/pages/communityPage/CommunityHospitalPage/CommunityHospitalMainPage/CommunityHospitalMainPage.jsx
@@ -30,13 +30,20 @@ const CommunityHospitalMainPage = () => {
 
   useEffect(() => {
     const isBack = sessionStorage.getItem('hospital_back');
+    const filterId = sessionStorage.getItem('hospital_filter');
 
     if (!isBack) {
       sessionStorage.setItem('hospital_filter', 0);
       return;
     }
 
-    setSelectFilterId(sessionStorage.getItem('hospital_filter'));
+    if (isBack && !filterId) {
+      sessionStorage.removeItem('hospital_back');
+      sessionStorage.setItem('hospital_filter', 0);
+      return;
+    }
+
+    setSelectFilterId(filterId);
     sessionStorage.removeItem('hospital_back');
   }, []);
 

--- a/src/pages/communityPage/CommunityHospitalPage/CommunityHospitalMainPage/CommunityHospitalMainPage.jsx
+++ b/src/pages/communityPage/CommunityHospitalPage/CommunityHospitalMainPage/CommunityHospitalMainPage.jsx
@@ -14,10 +14,9 @@ const CommunityHospitalMainPage = () => {
     { id: 0, title: '1km 이내', radius: 1000 },
     { id: 1, title: '5km 이내', radius: 5000 },
     { id: 2, title: '10km 이내', radius: 10000 },
-    { id: 3, title: '20km 이내', radius: 20000 },
   ];
 
-  const [isLocationUpdate, setIsLocationUpdate] = useState(true);
+  const [isLocationUpdate, setIsLocationUpdate] = useState(false);
   const checkUserLocation = useCurrentLocation({ isLocationUpdate, setIsLocationUpdate });
 
   const onClickBackgroundHandler = () => {

--- a/src/pages/communityPage/CommunityHospitalPage/CommunityHospitalMainPage/FilterMenu.jsx
+++ b/src/pages/communityPage/CommunityHospitalPage/CommunityHospitalMainPage/FilterMenu.jsx
@@ -30,6 +30,7 @@ const FilterMenu = ({ onBackgroundClick, onClickFilter, itemList }) => {
   };
 
   const onClickFilterHandler = (id) => {
+    sessionStorage.setItem('hospital_filter', id);
     onClickFilter(id);
   };
 

--- a/src/pages/communityPage/CommunityHospitalPage/CommunityHospitalMainPage/HospitalList.jsx
+++ b/src/pages/communityPage/CommunityHospitalPage/CommunityHospitalMainPage/HospitalList.jsx
@@ -1,47 +1,71 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import axios from 'axios';
 import { UserLocationContextStore } from '../../../../context/UserLocationContext';
 import HospitalItem from './HospitalItem';
+import Button from '../../../../components/common/Button/Button';
 
 const HospitalList = ({ radius }) => {
   const KAKAOMAP_API = process.env.REACT_APP_KAKAOMAP_API;
   const [hospitalList, setHospitalList] = useState([]);
+  const [isEndPage, setIsEndPage] = useState(true);
+  const [page, setPage] = useState(1);
 
   const { longitude, latitude } = useContext(UserLocationContextStore);
+
+  useEffect(() => {
+    setPage(1);
+    setIsEndPage(true);
+    setHospitalList([]);
+  }, [radius]);
+
+  const getHospital = useCallback(async () => {
+    const header = { headers: { Authorization: `KakaoAK ${KAKAOMAP_API}` } };
+
+    let url = `https://dapi.kakao.com/v2/local/search/keyword.json?x=${longitude}&y=${latitude}&radius=${radius}&sort=distance&query=동물병원&page=${page}&size=10`;
+
+    await axios
+      .get(url, header)
+      .then((res) => {
+        setHospitalList(page > 1 ? (prev) => prev.concat(res.data.documents) : res.data.documents);
+        setIsEndPage(res.data.meta.is_end);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, [longitude, latitude, radius, page]);
 
   useEffect(() => {
     if (!latitude || !longitude) {
       return;
     }
 
-    const getHospital = async () => {
-      const header = { headers: { Authorization: `KakaoAK ${KAKAOMAP_API}` } };
-
-      await axios
-        .get(
-          `https://dapi.kakao.com/v2/local/search/keyword.json?x=${longitude}&y=${latitude}&radius=${radius}&sort=distance&query=동물병원`,
-          header,
-        )
-        .then((res) => {
-          setHospitalList(res.data.documents);
-        })
-        .catch((err) => {
-          console.log(err);
-        });
-    };
-
     getHospital();
-  }, [longitude, latitude, radius]);
+  }, [longitude, latitude, radius, page]);
+
+  const getNextPageData = () => {
+    setPage((prev) => prev + 1);
+  };
 
   return (
-    <HospitalListWrapper>
-      {hospitalList.length > 0 ? (
-        hospitalList.map((hospital) => <HospitalItem key={hospital.id} hospitalInfo={hospital} />)
+    <>
+      <HospitalListWrapper>
+        {hospitalList.length > 0 ? (
+          hospitalList.map((hospital) => <HospitalItem key={hospital.id} hospitalInfo={hospital} />)
+        ) : (
+          <>없음</>
+        )}
+      </HospitalListWrapper>
+      {isEndPage || page > 2 ? (
+        <></>
       ) : (
-        <>없음</>
+        <ButtonWrapper>
+          <Button size='MS' onClickHandler={getNextPageData}>
+            더보기
+          </Button>
+        </ButtonWrapper>
       )}
-    </HospitalListWrapper>
+    </>
   );
 };
 
@@ -51,4 +75,9 @@ const HospitalListWrapper = styled.ol`
   & > li:not(:last-child) {
     margin-bottom: 2.3rem;
   }
+`;
+
+const ButtonWrapper = styled.div`
+  margin-top: 2.3rem;
+  text-align: center;
 `;

--- a/src/pages/communityPage/CommunityLayout.jsx
+++ b/src/pages/communityPage/CommunityLayout.jsx
@@ -18,7 +18,7 @@ const CommunityLayout = ({
       {navType === 'mainNav' ? (
         <TopMainNav title='집사생활' viewSearchBtn={false} />
       ) : navType === 'titleNav' ? (
-        <TopTitleNav title={`${title} 상세 정보`} viewMoreBtn={false} />
+        <TopTitleNav title={`${title} 상세 정보`} viewMoreBtn={false} isHospital={true} />
       ) : (
         <></>
       )}

--- a/src/pages/communityPage/CommunityWeatherPage/CommunityWeatherPage.jsx
+++ b/src/pages/communityPage/CommunityWeatherPage/CommunityWeatherPage.jsx
@@ -16,9 +16,9 @@ const CommunityWeatherPage = () => {
   const [dateInfo, setDateInfo] = useState({});
   const [weatherInfo, setWeatherInfo] = useState({});
   const [dustInfo, setDustInfo] = useState({});
-  const [isLocationUpdate, setIsLocationUpdate] = useState(true);
   const [walkingScore, setWalkingScore] = useState(0);
 
+  const [isLocationUpdate, setIsLocationUpdate] = useState(false);
   const checkUserLocation = useCurrentLocation({ isLocationUpdate, setIsLocationUpdate });
 
   useEffect(() => {


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 동물병원 근처 동물병원이 최대 15개만 보이는 버그를 수정했습니다.
- 동물병원 메인 페이지 -> 상세 페이지 접속 -> 상세 페이지에서 뒤로가기 -> 기존 거리 필터를 유지하는 기능을 추가했습니다.
- 기타 사소한 부분을 수정했습니다.
  - 기존에는 거리 당 동물병원을 최대 45개씩 가져왔으나 최대 30개만 가져오도록 수정
  - 거리 필터 축소
    - 기존 : 1km, 5km, 10km, 20km
    - 수정 : 1km, 5km, 10km
    - 카카오 API를 이용했을 때 한 거리당 최대 45개까지만 가져올 수 있음. 무한정으로 가져올 수 있는게 아니다보니 10km와 20km의 데이터가 동일한 경우가 많았음. 따라서 20km 필터를 삭제함.


## 기대 결과
- `더보기 버튼`을 클릭해서 동물병원을 최대 30개까지 확인할 수 있습니다.
- 동물병원 메인 페이지 -> 상세 페이지 접속 -> 상세 페이지에서 뒤로가기 -> 기존 거리 필터가 유지됩니다.
  - 뒤로가기를 하지 않은 경우에는 `1km` 기준으로 보여집니다.


## 리뷰어에게 전달 사항
- 상세 페이지에서 뒤로가기 했을 때 거리 필터 뿐만 아니라 보고 있던 위치까지 유지하는 기능을 추가해보려 했으나 아직 저의 실력 부족으로 완성하지 못했습니다. 발견된 버그를 모두 수정한 후 다시 도전해보겠습니다..🥺


## 스크린샷
### 더보기 버튼으로 동물병원 리스트 가져오기
![123123](https://user-images.githubusercontent.com/105365737/210057264-c92813d9-b128-4258-a479-eb3abff5e879.gif)
- 데이터를 추가로 가져올 때, 무한 스크롤으로 구현할지 더보기 버튼으로 구현할지 고민했는데 더보기 버튼으로 구현했습니다.
  - 동물병원 리스트는 가져올 때부터 현재 위치에서 가까운 순으로 정렬되어 서버에서 넘어옵니다.
  - 사용자 입장에서 생각해봤을 때, 가까운 동물병원보다 먼 동물병원을 궁금해하는 경우는 상대적으로 적을 것 같단 생각이 들었습니다.
  - 따라서 사용자가 필요할때만 정보를 추가로 볼 수 있도록 더보기 버튼으로 구현했습니다.

### 상세 페이지에서 뒤로가기 시 기존 거리 필터 유지
![5km](https://user-images.githubusercontent.com/105365737/210057564-bba218ea-31a4-4475-aa47-c901bcc2985c.gif)

## 관련 이슈 번호
close : #386 #404 
