### PR TITLE
fix: 프로필 계정 ID 수정 시 프로필 페이지 오류 현상 개선 (#383)

### DIFF
--- a/src/pages/ProfileModificationPage/ProfileModificationPage.jsx
+++ b/src/pages/ProfileModificationPage/ProfileModificationPage.jsx
@@ -73,7 +73,8 @@ const ProfileModificationPage = () => {
     };
 
     axios(option)
-      .then((res) => {
+      .then(() => {
+        localStorage.setItem('accountname', accountName);
         navigate('/profile');
       })
       .catch((err) => {

--- a/src/pages/profilePage/ProfilePage.jsx
+++ b/src/pages/profilePage/ProfilePage.jsx
@@ -51,6 +51,7 @@ const ProfilePage = () => {
           setUserProfileInfo(res.data.profile);
         })
         .catch((err) => {
+          window.location.reload();
           setIsLoading(false);
           console.error(err);
         });


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 프로필 계정 ID 수정 시 프로필 페이지가 먹통이 되는 오류를 개선하기 위해 수정했습니다.

## 기대 결과
- 프로필 계정 ID 수정 후, 변경된 계정 ID로 원하는 페이지를  정상적으로 사용 가능합니다.


## 리뷰어에게 전달 사항
- 좀 더 효율적인 방법을 고민하다 실패하여, 우선 버그가 수정되어야 함을 우선으로 하여 작업했습니다.
- 이후 효율적인 렌더링을 위해 리팩토링이 진행될 수 있습니다.


## 스크린샷
![계정 ID 수정](https://user-images.githubusercontent.com/112460383/210128508-e2902ec5-8dab-4f33-8d60-429bb346ed15.gif)


## 관련 이슈 번호
close : #383 
