### PR TITLE
fix: UserAccountInfo 내부 내용이 길어질 경우 넘치는 현상 (#416)

### DIFF
--- a/src/components/common/userItem/UserAccountInfo/UserAccountInfo.jsx
+++ b/src/components/common/userItem/UserAccountInfo/UserAccountInfo.jsx
@@ -14,7 +14,7 @@ const UserAccountInfo = ({ keyword = '', accountname, username, image }) => {
     <UserLink to={`/profile/${accountname}`}>
       <ProfileImage src={image} alt={`${username}님의 프로필사진`} width='50' />
       <AccountInfoWrapper>
-        <UserName>
+        <UserName className='ellipsis'>
           {/* TODO : username은 keyword와 겹치는데 accountname은 겹지 않는다면, 그냥 username을 반환 / 그게 아니라면, keyword 만 색상 변경하여 출력 */}
           {!usernameValidate && accountnameValidate ? (
             <>{username}</>
@@ -26,7 +26,7 @@ const UserAccountInfo = ({ keyword = '', accountname, username, image }) => {
             </span>
           )}
         </UserName>
-        <UserId>{accountname}</UserId>
+        <UserId className='ellipsis'>{accountname}</UserId>
       </AccountInfoWrapper>
     </UserLink>
   );
@@ -49,6 +49,7 @@ const AccountInfoWrapper = styled.div`
 
 const UserName = styled.strong`
   display: block;
+  max-width: 20rem;
   margin-bottom: 0.6rem;
   font-size: var(--fs-md);
   font-weight: 500;
@@ -62,6 +63,7 @@ const Keyword = styled.span`
 
 const UserId = styled.strong`
   display: block;
+  max-width: 20rem;
   font-size: var(--fs-sm);
   color: var(--sub-text-color);
 


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- UserAccountInfo 내부 내용이 길어질 경우 넘치는 현상을 해결하기 위해 수정했습니다.
  - 사용자명, 아이디 max-width를 20rem으로 설정했습니다.
  - 20rem을 넘어갈 경우 말줄임 스타일을 적용했습니다.


## 기대 결과
- 사용자명, 아이디가 길어도 UserAccountInfo를 넘어가지 않습니다.


## 리뷰어에게 전달 사항
- 사용자명, 아이디를 화면에 보여주는 페이지를 맡으신 분들은(프로필 페이지 등) 각자 맡으신 페이지에서`abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz` 계정 확인 시 오류가 없는지 한번씩 체크부탁드립니다.


## 스크린샷
- 수정 전
<img width="362" alt="스크린샷 2023-01-02 오전 11 45 56" src="https://user-images.githubusercontent.com/105365737/210192193-6c9ef3a1-1f8a-4c5b-bada-9ac9c0cc2330.png">

- 수정 후
<img width="354" alt="스크린샷 2023-01-02 오전 11 57 21" src="https://user-images.githubusercontent.com/105365737/210192231-20e9c1d0-8cac-4061-a1a9-30170267c6b1.png">

## 관련 이슈 번호
close : #416 
