### PR TITLE
fix: 캐러셀 높이값 수정 및 하단과의 간격 추가 (#423)

### DIFF
--- a/src/components/common/Post/Post.jsx
+++ b/src/components/common/Post/Post.jsx
@@ -68,6 +68,7 @@ const Post = ({ post = {} }) => {
                 {imageFile[0] ? (
                   <SwiperWrapper>
                     <Swiper
+                      style={swiperStyle}
                       spaceBetween={30}
                       pagination={{
                         clickable: true,
@@ -178,9 +179,13 @@ const ContentImg = styled.img`
   border-radius: 10px;
   margin-bottom: 1.2rem;
 `;
+const swiperStyle = {
+  height: '228px',
+};
 
 const Div = styled.div`
   display: flex;
+  margin-top: 1.2rem;
   margin-bottom: 1.6rem;
 `;
 


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 게시물에서 이미지 짤리는 현상 및 댓글과의 간격이 거슬려서 수정했습니다.


## 기대 결과
- 사진을 잘리지 않고  크게 볼 수 있습니다


## 스크린샷
<img width="406" alt="image" src="https://user-images.githubusercontent.com/96304623/210211966-bcf9353e-06be-4e1c-b426-a4ad33fd310b.png">


## 관련 이슈 번호
close : #423