### PR TITLE
refactor: 프로필 소개, 계정 ID에 대한 프로필 세팅 페이지 리팩토링 (#426)

### DIFF
--- a/src/pages/ProfileSettingsPage/InputAccountName.jsx
+++ b/src/pages/ProfileSettingsPage/InputAccountName.jsx
@@ -30,7 +30,7 @@ const InputAccountName = ({
       inputRef.current.style.borderBottom = '1px solid var(--border-color)';
     }
 
-    const regex = /^[._a-zA-z0-9]{0,10}$/;
+    const regex = /^[a-z0-9A-Z_.]{0,}$/;
 
     const option = {
       url: 'https://mandarin.api.weniv.co.kr/user/accountnamevalid',

--- a/src/pages/ProfileSettingsPage/ProfileInfo.jsx
+++ b/src/pages/ProfileSettingsPage/ProfileInfo.jsx
@@ -21,7 +21,7 @@ const ProfileInfo = ({
   intro,
   image,
 }) => {
-  const onChangeInputHandler = (event) => {
+  const onChangeImgInputHandler = (event) => {
     const [file] = event.target.files;
 
     imageCompression(file, {
@@ -62,9 +62,7 @@ const ProfileInfo = ({
 
   // enter 입력 확인
   const onCheckEnter = (e) => {
-    if (disabledButton === false && e.key === 'Enter') {
-      onClickStartButtonHandler();
-    }
+    disabledButton === false && e.key === 'Enter' && onClickStartButtonHandler();
   };
 
   return (
@@ -83,7 +81,7 @@ const ProfileInfo = ({
       </label>
       <input
         onChange={(event) => {
-          onChangeInputHandler(event);
+          onChangeImgInputHandler(event);
         }}
         className='sr-only'
         type='file'
@@ -106,7 +104,7 @@ const ProfileInfo = ({
           labelText='계정 ID'
           inputType='text'
           id='userIdInput'
-          placeholder='영문, 숫자, 특수문자(,), (_)만 사용 가능합니다.'
+          placeholder='영문, 숫자, 특수문자(.), (_)만 사용 가능합니다.'
           maxLength='10'
           accountNameFunction={accountNameFunction}
           defaultAcconutName={defaultAcconutName}
@@ -117,7 +115,7 @@ const ProfileInfo = ({
           inputType='text'
           id='userIntroInput'
           placeholder='자신과 판매할 상품에 대해 소개해 주세요.'
-          maxLength='25'
+          maxLength='100'
           introFunction={introFunction}
           intro={intro}
         ></InputIntro>


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 아래와 같은 변경이 필요해서 수정하였습니다.
  - 프로필 설정 페이지 내 불필요한 코드를 제거
  - #250 에서 언급한 계정 ID 정규식 업데이트 (`` ` ``, ``^``, ``공백 입력`` 대응) 
  - 원할한 소개작성을 위한 소개 input 창 입력 제한 100글자로 증가


## 기대 결과
- 정규식이 업데이트되어 보다 정확한 유효성 검사가 가능해집니다.
- 이전보다 많은 양을 소개란에 작성할 수 있습니다.


## 리뷰어에게 전달 사항
- 없습니다.


## 스크린샷
![프로필 세팅 페이지 수정](https://user-images.githubusercontent.com/112460383/210256791-45957aa1-54e7-474c-b398-7252fc071759.gif)



## 관련 이슈 번호
close : #426 
