### PR TITLE
fix: 게시물 글이 길 경우 화면 밖으로 빠져나가는 현상 word-break 속성 추가로 해결 (#424)

### DIFF
--- a/src/components/common/Post/Post.jsx
+++ b/src/components/common/Post/Post.jsx
@@ -170,6 +170,7 @@ const ContentText = styled.p`
   font-weight: 400;
   font-size: var(--fs-md);
   line-height: 1.8rem;
+  word-break: break-word;
 `;
 
 const ContentImg = styled.img`


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 포스트의 컨텐츠가 길 경우 화면밖으로 나가버리는 현상을 방지하기 위해 
` word-break: break-word` 속성 부여했습니다.


## 기대 결과
- 이제 컨텐츠가 길어도 화면 밖으로 삐져나가지 않습니다.


## 스크린샷
<img width="386" alt="image" src="https://user-images.githubusercontent.com/96304623/210257984-c7d9f6a3-5321-440f-a9c1-c21ab3b253b4.png">


## 관련 이슈 번호
close : #424
