### PR TITLE
fix: 무한스크롤 기능 추가시 가장 마지막 게시글 보이지 않는 현상 수정 (#429)

### DIFF
--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -88,7 +88,9 @@ const FeedPage = () => {
                 {isFollowingPost.map((post, i) =>
                   // isFollowingPost의 마지막 요소라면 ref추가
                   isFollowingPost.length - 1 === i ? (
-                    <div key={post.id} ref={ref} />
+                    <div key={post.id} ref={ref}>
+                      <Post post={post} />
+                    </div>
                   ) : (
                     <div key={post.id}>
                       <Post post={post} />

--- a/src/pages/profilePage/ProfilePost/ProfilePost.jsx
+++ b/src/pages/profilePage/ProfilePost/ProfilePost.jsx
@@ -99,9 +99,11 @@ const ProfilePost = ({ setEmptyPost, emptyProduct }) => {
                 <h3 className='sr-only'>리스트형 포스트 목록</h3>
                 {myPostList.map((post, i) =>
                   myPostList.length - 1 === i ? (
-                    <div key={post.id} ref={ref} />
+                    <div key={i} ref={ref}>
+                      <Post key={post.id} post={post} />
+                    </div>
                   ) : (
-                    <div key={post.id}>
+                    <div key={i}>
                       <Post key={post.id} post={post} />
                     </div>
                   ),


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
-  무한스크롤 기능을 추가했더니 가장 마지막의 게시글이 보이지 않아 수정했습니다. 


## 기대 결과
- 마지막 게시글까지 잘 보입니다.



## 스크린샷
<img width="394" alt="image" src="https://user-images.githubusercontent.com/96304623/210264474-d7ece72e-9aa2-4c26-9854-47e8e92414e1.png">


## 관련 이슈 번호
close : #
