### PR TITLE
fix: 프로필 주소 변경시 프로필 포스트들이 재렌더링 되지 않는 현상 해결 (#421)

### DIFF
--- a/src/pages/profilePage/ProfilePage.jsx
+++ b/src/pages/profilePage/ProfilePage.jsx
@@ -74,7 +74,7 @@ const ProfilePage = () => {
           >
             <ProfileHeader profileData={userProfileInfo} profileUserAccountname={accountname} />
             <ProfileProduct setEmptyProduct={setEmptyProduct} />
-            <ProfilePost setEmptyPost={setEmptyPost} emptyProduct={emptyProduct} />
+            <ProfilePost setEmptyPost={setEmptyPost} emptyProduct={emptyProduct} key={location.key} />
           </ContentsLayout>
           <TabMenu currentMenuId={4} />
         </>


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타

## 왜 코드를 추가/변경하였나요?
- 프로필 주소 변경시 프로필 포스트들이 재렌더링 되지 않는 현상이 발생하여 해결했습니다.

## 해결방법 
* `location.key()`사용
=> 위치를 나타내는 고유 문자열. useLocation으로 받아오는 값이 갱신되면 새로 컴포넌트를 불러오는 코드라고 합니다. 
현재 post 부분이 현재 갱신되고 있지 않아서 profilePost에 key값으로 `location.key()`를 부여해주었습니다. 
( 승연님의 도움을 받아 검색하는 방법도 새로 변경해보았습니다!)
<a href='https://stackoverflow.com/questions/46820682/how-do-i-reload-a-page-with-react-router'>참고한 사이트</a>

### 시도해본것들
이전에는 단순히 useEffect의 의존성배열에 `location.pathname`이나 useParams로 가져온`accountname` 등을 사용해서, 
주소값이 변경될 경우 useEffect의 첫번째 요소가 실행될거라고 생각해서 시도해봤습니다. 
``` useEffect(() => {
    console.log(location.pathname);
    getPost()
  }, [location.pathname]);
```
<img width="214" alt="image" src="https://user-images.githubusercontent.com/96304623/210322089-198a88ca-aa5f-498b-973a-4fe08fe8459d.png">

location의 변화는 감지하지만 재렌더링을 발생시키지는 않았습니다. ㅠㅠ

### 다른 시도
원범멘토님께 코드리뷰를 받았는데, 몇가지 피드백을 주셨습니다.
```
1. 리액트의 리렌더링은 컴포넌트의 props 또는 state가 바뀌었을때 발생한다. 하지만 이 코드에서는 profile 정보가 바뀌어도 post의 상태가 바뀌는 부분이 없는 것 같다.
2. 게시글 리스트를 언제 초기화 시켜야하는지
3. 무한스크롤 초기화는 언제 시켜야하는지
4. done state값을 언제 다시 false로 바꿔야하는지?
```

등등을 고려해보라고 하셨습니다. 
피드백을 받고 이런저런 시도를 해봤지만 아직 해결이 되지 않았기 때문에
일단 location값의 변동이 감지되면 랜더링되는 `location.key()`를 사용했습니다. 
코드 리팩토링하면서 피드백 반영하여 트러블슈팅 해볼 예정입니다!!!


## 기대 결과
- 프로필 페이지의 url이 바뀌면 profilePost도 자동으로 랜더링됩니다.


## 리뷰어에게 전달 사항
- 함께 고민해주셔서 감사합니다


## 스크린샷

https://user-images.githubusercontent.com/96304623/210323644-102b18f9-f62a-4c53-b2ed-807c8afc3d7b.mov



## 관련 이슈 번호
close : #421
