### PR TITLE
fix: 게시물 업로드 및 수정시, 이미지 3장이상 업로드 불가하도록 수정 (#434)

### DIFF
--- a/src/pages/PostUploadPage/ImageUploadButton.jsx
+++ b/src/pages/PostUploadPage/ImageUploadButton.jsx
@@ -43,7 +43,11 @@ const ImageUploadButton = ({ className, setUploadImg, uploadImg, inputRef }) => 
     reader.readAsDataURL(Blob);
     e.target.value = '';
     reader.onload = () => {
-      setImageUrl((imageUrl) => [...imageUrl, reader.result]);
+      if (imageUrl.length > 2) {
+        alert('사진은 3장까지 업로드 가능합니다.');
+      } else {
+        setImageUrl((imageUrl) => [...imageUrl, reader.result]);
+      }
     };
   };
 


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 게시물 업로드 및 수정시, 이미지 3장이상 업로드가 불가능하여야 하기 때문이다.


## 기대 결과
- 3장 이상 업로드를 수행할 시, alert 창이 뜬다.


## 리뷰어에게 전달 사항
- 확인부탁드려요~!


## 관련 이슈 번호
close : #434 
