### PR TITLE
fix: ProfilePost 앨범뷰 키 중복 경고 해결 (#451)

### DIFF
--- a/src/pages/ProfilePage/ProfilePost/ProfilePost.jsx
+++ b/src/pages/ProfilePage/ProfilePost/ProfilePost.jsx
@@ -110,18 +110,18 @@ const ProfilePost = ({ setEmptyPost, emptyProduct }) => {
                 {myPostList.map((post, i) => {
                   return post.image ? (
                     post.image.includes(',') ? (
-                      <li>
+                      <li key={post.id}>
                         <Link to={`/post/${post.id}`}>
-                          <img key={post.id} src={post.image.split(',')[0]} alt='썸네일 이미지' />
+                          <img src={post.image.split(',')[0]} alt='썸네일 이미지' />
                           <img className='layer-icon' src={LAYERS_ICON} alt='레이어 아이콘' />
                         </Link>
                       </li>
                     ) : (
-                      <>
+                      <li key={post.id}>
                         <Link to={`/post/${post.id}`}>
                           <img key={post.id} src={post.image} alt='썸네일 이미지'></img>
                         </Link>
-                      </>
+                      </li>
                     )
                   ) : null;
                 })}


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- ProfilePost 앨범뷰 키 중복 경고 해결을 위해 수정했습니다.


## 기대 결과
- ProfilePost 앨범뷰 키 중복 경고가 해결됩니다.


## 리뷰어에게 전달 사항
- 반복 요소의 가장 상위 태그가 아니라 내부 태그에 key가 적용되어 있어서 경고 발생 (즉 반복되는 모든 요소의 상위 태그에는 key가 누락되어 있어서)
- 그래서 가장 상위 태그에 key 적용


## 스크린샷
### 수정 전
![스크린샷 2023-01-05 오후 2 45 07](https://user-images.githubusercontent.com/105365737/210711365-8653d74e-2008-49ef-a3aa-a76b451d699a.png)

### 수정 후
![스크린샷 2023-01-05 오후 2 54 40](https://user-images.githubusercontent.com/105365737/210711561-b35726c9-4d1e-42ae-b069-8cba2404208c.png)


## 관련 이슈 번호
close : #451 
