### PR TITLE
refactor: 간헐적으로 상품 수정 시 판매 중인 상품에 바로 반영이 안 되는 현상 수정 및 고용량 이미지 업로드 과정에서 발생하는 소요 시간에 대한 UX 개선 (#457, #458)

### DIFF
--- a/src/pages/ProductPage/ProductModificationPage/ProductModificationPage.jsx
+++ b/src/pages/ProductPage/ProductModificationPage/ProductModificationPage.jsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useContext } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { AuthContextStore } from '../../../context/AuthContext';
 import ProductRegistrationPage from '../ProductRegistrationPage/ProductRegistrationPage';
 
 const ProductModificationPage = () => {
   const { userToken } = useContext(AuthContextStore);
+
+  const navigate = useNavigate();
 
   const params = useParams();
 
@@ -77,7 +79,9 @@ const ProductModificationPage = () => {
     };
 
     axios(option)
-      .then((res) => {})
+      .then(() => {
+        navigate('/profile');
+      })
       .catch((err) => {
         console.error(err);
       });

--- a/src/pages/ProductPage/ProductRegistrationPage/ProductRegistrationPage.jsx
+++ b/src/pages/ProductPage/ProductRegistrationPage/ProductRegistrationPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useContext } from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import styled from 'styled-components';
 import TopUploadNav from '../../../components/common/TopNavBar/TopUploadNav';
@@ -23,6 +23,8 @@ const ProductRegistrationPage = ({
   linkMod,
   itemImageMod,
 }) => {
+  const navigate = useNavigate();
+
   const [itemName, setItemName] = useState('');
   const itemNameFunction = (value) => {
     setItemName(value);
@@ -91,7 +93,9 @@ const ProductRegistrationPage = ({
     };
 
     axios(option)
-      .then((res) => {})
+      .then(() => {
+        navigate('/profile');
+      })
       .catch((err) => {
         console.error(err);
       });
@@ -121,19 +125,17 @@ const ProductRegistrationPage = ({
 
   return (
     <>
-      <Link to='/profile'>
-        <TopUploadNav
-          activeModButton={activeModButton}
-          activeButton={disabledButton}
-          onClick={() => {
-            if (onClickProductModificationHandler) {
-              onClickProductModificationHandler();
-            } else {
-              onClickProductRegistrationHandler();
-            }
-          }}
-        />
-      </Link>
+      <TopUploadNav
+        activeModButton={activeModButton}
+        activeButton={disabledButton}
+        onClick={() => {
+          if (onClickProductModificationHandler) {
+            onClickProductModificationHandler();
+          } else {
+            onClickProductRegistrationHandler();
+          }
+        }}
+      />
 
       <ContentsLayout isTabMenu='false' padding='0'>
         <Section>

--- a/src/pages/ProductPage/ProductRegistrationPage/ProductRegistrationPage.jsx
+++ b/src/pages/ProductPage/ProductRegistrationPage/ProductRegistrationPage.jsx
@@ -10,6 +10,7 @@ import PriceInput from './PriceInput';
 import ItemLinkInput from './ItemLinkInput';
 import { AuthContextStore } from '../../../context/AuthContext';
 import imageCompression from 'browser-image-compression';
+import Loading from '../../../components/common/Loading/Loading';
 
 const ProductRegistrationPage = ({
   activeModButton,
@@ -24,6 +25,8 @@ const ProductRegistrationPage = ({
   itemImageMod,
 }) => {
   const navigate = useNavigate();
+
+  const [isLoading, setIsLoading] = useState(true);
 
   const [itemName, setItemName] = useState('');
   const itemNameFunction = (value) => {
@@ -48,12 +51,14 @@ const ProductRegistrationPage = ({
   const [itemImage, setItemImage] = useState('');
 
   const onChangeInputHandler = (event) => {
+    setIsLoading(false);
     const [file] = event.target.files;
 
     imageCompression(file, {
       maxSizeMB: 0.08,
       maxWidthOrHeight: 320,
     }).then((compressedFile) => {
+      setIsLoading(true);
       const newFile = new File([compressedFile], file.name, { type: file.type });
 
       const readerBlob = new FileReader();
@@ -142,7 +147,19 @@ const ProductRegistrationPage = ({
           <h2 className='sr-only'>상품 정보</h2>
           <P>이미지 등록</P>
           <Label htmlFor='productImg'>
-            {thumbnailImg ? <Img src={thumbnailImg} alt='' /> : itemImageMod ? <Img src={itemImageMod} alt='' /> : ''}
+            {isLoading ? (
+              thumbnailImg ? (
+                <Img src={thumbnailImg} alt='' />
+              ) : itemImageMod ? (
+                <Img src={itemImageMod} alt='' />
+              ) : (
+                ''
+              )
+            ) : (
+              <LoadingWrapper>
+                <Loading />
+              </LoadingWrapper>
+            )}
           </Label>
           <input
             onChange={(event) => {
@@ -240,4 +257,11 @@ const Form = styled.form`
   gap: 1.6rem;
   width: 100%;
   margin-bottom: 3rem;
+`;
+
+const LoadingWrapper = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 `;


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [x] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 간헐적으로 상품 수정 시 판매 중인 상품에 바로 반영이 안 되는 현상이 있어 수정했습니다.
- 고용량 이미지 업로드 과정에서 발생하는 소요 시간에 대한 UX 개선을 하고자 수정했습니다.


## 기대 결과
- 상품 수정 시 판매 중인 상품에 즉각 반영 됩니다.
- 고용량 이미지 업로드 과정에서 발생하는 소요 시간에 대해 로딩 컴포넌트를 추가하여 UX 개선이 이루어졌습니다.


## 리뷰어에게 전달 사항
- 명확한  검증을 위해 21466 * 16981 /  17MB 이미지를 사용했습니다.
- 현재는 로딩중에도 저장 버튼이 활성화되어 있습니다. 추후, 로딩이 완료되면 버튼이 활성화될 수 있도록 추가 작업도 진행 예정입니다.



## 스크린샷

![상품 수정 개선 및 UX 개선](https://user-images.githubusercontent.com/112460383/211326047-99e117af-7d17-46d6-bf65-526dd5721666.gif)

## 관련 이슈 번호
close : #457 
close : #458 