### PR TITLE
feat: feed페이지 탑버튼 추가 (#436)

### DIFF
--- a/src/components/common/Button/TopButton.jsx
+++ b/src/components/common/Button/TopButton.jsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { BOTTOM_ARROW_ICON } from '../../../styles/CommonIcons';
+const TopButton = () => {
+  const [showBtn, setShowBtn] = useState(false);
+
+  const scrollToTop = () => {
+    window.scroll({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  useEffect(() => {
+    const showBtnClick = () => {
+      if (window.scrollY > 700) {
+        setShowBtn(true);
+      } else {
+        setShowBtn(false);
+      }
+    };
+    window.addEventListener('scroll', showBtnClick);
+    return () => {
+      window.removeEventListener('scroll', showBtnClick);
+    };
+  }, []);
+
+  return (
+    <>
+      {showBtn && (
+        <TopBtnDiv>
+          <TopBtn onClick={scrollToTop}>
+            <img src={BOTTOM_ARROW_ICON} alt='탑버튼' />
+          </TopBtn>
+        </TopBtnDiv>
+      )}
+    </>
+  );
+};
+
+const TopBtnDiv = styled.div`
+  position: fixed;
+  width: 390px;
+  z-index: 200;
+`;
+const TopBtn = styled.button`
+  position: absolute;
+  right: 30px;
+  top: 530px;
+  width: 30px;
+  height: 30px;
+  background-color: var(--main-color);
+  border-radius: 50%;
+  transform: rotateX(180deg);
+
+  img {
+    color: white;
+    filter: invert(100%);
+  }
+`;
+
+export default TopButton;

--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import axios from 'axios';
 import { AuthContext, AuthContextStore } from '../../context/AuthContext';
 import { useInView } from 'react-intersection-observer';
+import TopButton from '../../components/common/Button/TopButton';
 
 import TopMainNav from '../.././components/common/TopNavBar/TopMainNav';
 import ContentsLayout from '../../components/layout/ContentsLayout/ContentsLayout';
@@ -94,6 +95,7 @@ const FeedPage = () => {
                   ),
                 )}
               </div>
+              <TopButton />
             </ContentsLayout>
           ) : (
             <EmptyFeedStyle>


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 피드페이지에 무한스크롤을 구현하였는데, 아래로 한참 내려가다보면 탑버튼이 있으면 좋을 것 같았습니다. 탑버튼 추가하였습니다!




## 스크린샷

https://user-images.githubusercontent.com/96304623/211718730-716f026d-bd75-475c-8946-d36637c1b3d9.mov



## 관련 이슈 번호
close : #436 
