### PR TITLE
fix: 이미지 미리 보기 로딩 중에도 버튼이 활성화되는 현상 수정 (#461)

### DIFF
--- a/src/pages/ProductPage/ProductRegistrationPage/ProductRegistrationPage.jsx
+++ b/src/pages/ProductPage/ProductRegistrationPage/ProductRegistrationPage.jsx
@@ -51,7 +51,7 @@ const ProductRegistrationPage = ({
   const [itemImage, setItemImage] = useState('');
 
   const onChangeInputHandler = (event) => {
-    setItemImage(''); // (등록) 이미지 로딩 중 버튼 활성화 방지
+    setItemImage('');
 
     setIsLoading(false);
     const [file] = event.target.files;
@@ -75,7 +75,7 @@ const ProductRegistrationPage = ({
       encodeFile(newFile);
       setThumbnailImg(newFile);
     });
-    itemImageModFunction(''); // (수정) 이미지 로딩 중 버튼 활성화 방지
+    itemImageModFunction('');
   };
 
   const { userToken } = useContext(AuthContextStore);

--- a/src/pages/ProductPage/ProductRegistrationPage/ProductRegistrationPage.jsx
+++ b/src/pages/ProductPage/ProductRegistrationPage/ProductRegistrationPage.jsx
@@ -51,6 +51,8 @@ const ProductRegistrationPage = ({
   const [itemImage, setItemImage] = useState('');
 
   const onChangeInputHandler = (event) => {
+    setItemImage(''); // (등록) 이미지 로딩 중 버튼 활성화 방지
+
     setIsLoading(false);
     const [file] = event.target.files;
 
@@ -73,6 +75,7 @@ const ProductRegistrationPage = ({
       encodeFile(newFile);
       setThumbnailImg(newFile);
     });
+    itemImageModFunction(''); // (수정) 이미지 로딩 중 버튼 활성화 방지
   };
 
   const { userToken } = useContext(AuthContextStore);
@@ -121,12 +124,12 @@ const ProductRegistrationPage = ({
   };
 
   useEffect(() => {
-    if (itemName && price && link && thumbnailImg) {
+    if (itemName && price && link && itemImage) {
       setDisabledButton(false);
     } else {
       setDisabledButton(true);
     }
-  }, [thumbnailImg, itemName, price, link]);
+  }, [itemName, price, link, itemImage]);
 
   return (
     <>


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [ ] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타


## 왜 코드를 추가/변경하였나요?
- 이미지 용량이 클수록 이미지 미리 보기를 위한 일정 시간이 소요되는데, 로딩이 끝나지 않았음에도 불구하고 버튼이 활성화되어 있는 현상이 있어 수정했습니다.


## 기대 결과
- 상품 등록 & 수정 시 이미지 미리보기 로딩이 끝나기 이전에는 버튼이 활성화되지 않습니다.


## 리뷰어에게 전달 사항
- 버튼 활성화를 명확하게 보이기 위해 21466 * 16981 / 17MB 이미지를 사용하여 로딩 시간을 길게 했습니다.


## 스크린샷
![이미지 업로드 시 버튼 활성화 수정](https://user-images.githubusercontent.com/112460383/211999353-706dd2c5-4842-4fe5-b3b5-27152d3f52e8.gif)


## 관련 이슈 번호
close : #461 
